### PR TITLE
Pass _convert_=all to remove traces of omegaconf types when instantiating pydantic objects

### DIFF
--- a/examples/inline.yaml
+++ b/examples/inline.yaml
@@ -12,6 +12,10 @@ parameters:
 
 context:
   _target_: nbprint.example.ExampleContext
+  params:
+    my_list:
+      - "item1"
+      - "item2"
 
 page:
   _target_: nbprint.example.ExampleReportPage

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -181,7 +181,7 @@ class Configuration(BaseModel):
 
             with initialize_config_dir(version_base=None, config_dir=folder, job_name=name):
                 cfg = compose(config_name=file, overrides=[f"+name={name}"])
-                config = instantiate(cfg)
+                config = instantiate(cfg, _convert_="all")
                 if not isinstance(config, Configuration):
                     config = Configuration(**config)
                 return config
@@ -189,9 +189,9 @@ class Configuration(BaseModel):
 
     def run(self, dry_run: bool = False) -> Optional[Path]:
         gen = self.generate()
+        ret = None
         if self.debug:
             pprint(gen)
-            ret = None
         if not dry_run:
             ret = self.outputs.run(self, gen)
 

--- a/nbprint/example/basic/context.py
+++ b/nbprint/example/basic/context.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import pandas as pd
 
@@ -10,3 +10,4 @@ __all__ = ("ExampleContext",)
 class ExampleContext(Context):
     string: str = ""
     df: Optional[pd.DataFrame] = None
+    params: Dict[str, Any] = {}

--- a/nbprint/example/basic/context.py
+++ b/nbprint/example/basic/context.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 import pandas as pd
+from pydantic import Field
 
 from nbprint import Context
 
@@ -10,4 +11,4 @@ __all__ = ("ExampleContext",)
 class ExampleContext(Context):
     string: str = ""
     df: Optional[pd.DataFrame] = None
-    params: Dict[str, Any] = {}
+    params: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
Fixes #163 using https://hydra.cc/docs/advanced/instantiate_objects/overview/#parameter-conversion-strategies