### PR TITLE
Fix pydantic warning for model validator in `Configuration` object. Fixes #165

### DIFF
--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -91,6 +91,7 @@ class Configuration(BaseModel):
     @model_validator(mode="after")
     def _attach_params_to_context(self) -> Self:
         self.context.parameters = self.parameters
+        return self
 
     def generate(self, **_) -> list[NotebookNode]:
         nb = new_notebook()


### PR DESCRIPTION
Updatd model validator for Configuration class to return self and suppress pydantic warning