### PR TITLE
fix: allow tall tables and code blocks to break across pages

### DIFF
--- a/js/src/js/preprocessing/measure.js
+++ b/js/src/js/preprocessing/measure.js
@@ -402,6 +402,59 @@ function cloneGTColumnHeaders(sourceThead) {
 }
 
 /**
+ * Override break-inside: avoid for non-table content taller than a single page.
+ * Tables are already handled by splitTallTables; this covers code blocks and
+ * other tall output wrappers that would otherwise be pushed to the next page.
+ *
+ * For tall code blocks (<pre>), we also wrap individual lines in block-level
+ * spans so pagedjs has breakpoints between lines (plain text nodes don't
+ * provide breakpoints).
+ */
+function allowTallContentToBreak(contentRoot, contentArea) {
+  for (const el of contentRoot.querySelectorAll(".jp-OutputArea-output")) {
+    // Skip elements already handled by splitTallTables
+    if (el.querySelector("[data-nbprint-table-chunk]")) continue;
+    if (el.getBoundingClientRect().height > contentArea.height) {
+      el.style.breakInside = "auto";
+
+      // Wrap code lines so pagedjs can break between them
+      for (const pre of el.querySelectorAll("pre")) {
+        wrapCodeLinesForBreaking(pre);
+      }
+    }
+  }
+}
+
+/**
+ * Wrap individual lines in a <pre> element with block-level spans
+ * that prevent mid-line breaks while allowing breaks between lines.
+ * This must run before pagedjs so it has breakpoints to work with.
+ */
+function wrapCodeLinesForBreaking(preElement) {
+  const codeEl = preElement.querySelector("code") || preElement;
+  if (codeEl.getAttribute("data-nbprint-lines") === "true") return;
+
+  const text = codeEl.textContent;
+  if (!text || !text.includes("\n")) return;
+
+  const lines = text.split("\n");
+  if (lines.length <= 1) return;
+
+  const fragment = document.createDocumentFragment();
+  for (const line of lines) {
+    const span = document.createElement("span");
+    span.style.display = "block";
+    span.style.breakInside = "avoid";
+    span.textContent = line;
+    fragment.appendChild(span);
+  }
+
+  codeEl.textContent = "";
+  codeEl.appendChild(fragment);
+  codeEl.setAttribute("data-nbprint-lines", "true");
+}
+
+/**
  * Run all pre-pagination preprocessing on the content root.
  *
  * @param {Element} contentRoot  The <main> element containing report content.
@@ -421,6 +474,7 @@ export function preprocess(contentRoot, configuration) {
   scaleOversizedCharts(contentRoot, contentArea);
   annotateTallTables(contentRoot, contentArea);
   splitTallTables(contentRoot, contentArea, configuration);
+  allowTallContentToBreak(contentRoot, contentArea);
 
   contentRoot.setAttribute("data-nbprint-preprocessed", "true");
 }

--- a/js/tests/structural.spec.js
+++ b/js/tests/structural.spec.js
@@ -160,6 +160,15 @@ test.describe("Structural assertions — overflow fixtures", () => {
       }
     });
 
+    test("table starts on page 1 alongside heading", async ({ page }) => {
+      const pages = await getPages(page);
+      const page1 = pages[0];
+      const headings = await page1.locator("h2").count();
+      const rows = await page1.locator("tr").count();
+      expect(headings).toBeGreaterThan(0);
+      expect(rows).toBeGreaterThan(0);
+    });
+
     test("no blank pages", async ({ page }) => {
       const pages = await getPages(page);
       for (let i = 0; i < pages.length; i++) {
@@ -201,6 +210,15 @@ test.describe("Structural assertions — overflow fixtures", () => {
     test("should span multiple pages", async ({ page }) => {
       const pages = await getPages(page);
       expect(pages.length).toBeGreaterThan(1);
+    });
+
+    test("code starts on page 1 alongside heading", async ({ page }) => {
+      const pages = await getPages(page);
+      const page1 = pages[0];
+      const headings = await page1.locator("h2").count();
+      const preBlocks = await page1.locator("pre").count();
+      expect(headings).toBeGreaterThan(0);
+      expect(preBlocks).toBeGreaterThan(0);
     });
 
     test("no blank pages", async ({ page }) => {

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b110be09571ab0c647e297220fd372d5bc501ede8c2c02e476e9d8c8e021b857
-size 18581
+oid sha256:6de884a95ad2a0a2660393b0b45c8008908aae282e0e3902730efec317a3efb8
+size 130854

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-10.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b286fb2289f40984975fdcacf534b561bd9a8d5ff6b0ca295506728fe532895
+size 135699

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-11.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:995759f74ce827417dbf9f225fd9c2b0ca4f59b5b35d329f0de31dcb8bae61ef
+size 18041

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-2.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:713f75ed490e6a8247615f6825428debec0e1e7cde4aaa633468e9756de66a2a
-size 125576
+oid sha256:e6d1cd49a5f9760e99b41e22fa06aaa99156cdb8cbde9579d3aa3eb8e836103a
+size 133463

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-3.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff368a4a0dd15a509720a4fa80d130b710b45b7764b2d89b933c2229beb3588c
+size 130090

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-4.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81d21f25d4cd9df98bcdf6ca5506b651b9e7b9382e23d20c4b690298eec3dc61
+size 132899

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-5.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4829d9ed5f189473f6c8e281a5df1b159a97b5aaa9f6655a8092514d4bd361d
+size 133116

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-6.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:128c4e8a7d987590b7b0f7faa4b4a6961292b62461fa9db49013b09ac019ed16
+size 133515

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-7.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0ea83e805c173e15ad34c9dee1adc1ad6f90758caaaca6d1ea8b4a30d6a720d
+size 133136

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-8.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e3f789b0efd780f11767febd922f2e48ab2b0f168d7ac48f8e152a3621b71a
+size 134245

--- a/js/tests/visual.spec.js-snapshots/code-line-integrity-page-9.png
+++ b/js/tests/visual.spec.js-snapshots/code-line-integrity-page-9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ed680051034b4ddfa7c17a553afb3d91b700b860f5681bbbb0fb9a4f68bdb8a
+size 134847

--- a/js/tests/visual.spec.js-snapshots/long-code-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/long-code-page-1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6576031dab2808dfd1a5ee85ddca586635da71d9a81765d665d813f7f153a31e
-size 8103
+oid sha256:9c1bd3b9f3d44340205788a7262c8f7ff8d8251a01ab9894f5cbd9e4831f1d4c
+size 247121

--- a/js/tests/visual.spec.js-snapshots/long-code-page-2.png
+++ b/js/tests/visual.spec.js-snapshots/long-code-page-2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c244ada583f5877a384e7ecc172d65f9d45478714b39c7d053d24547773e249
-size 248823
+oid sha256:d8d059d0b79dfdfe3e392f911ded5082e28d6439eae33b3ad7807ed09cdcdae4
+size 214620

--- a/js/tests/visual.spec.js-snapshots/long-code-page-3.png
+++ b/js/tests/visual.spec.js-snapshots/long-code-page-3.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4aad72c88de8788c7bbe4d083261ac13bfe56f3de2eab9893a65dcc9c19b5b63
-size 8304

--- a/nbprint/config/__init__.py
+++ b/nbprint/config/__init__.py
@@ -1,5 +1,7 @@
 from .base import *
+from .cell import *
 from .common import *
 from .content import *
 from .core import *
+from .magic import *
 from .outputs import *

--- a/nbprint/config/cell.py
+++ b/nbprint/config/cell.py
@@ -1,0 +1,118 @@
+"""Runtime API for annotating notebook cells with nbprint metadata.
+
+``NBPrintCell`` is designed to be used *inside* notebook cells at execution
+time.  It emits a hidden ``display()`` output using a custom MIME type so
+that the metadata survives in the cell's output list and can be picked up
+by ``_cell_to_content`` during notebook ingestion.
+
+Usage::
+
+    from nbprint import NBPrintCell, Style, Font
+
+    # Simple: mark this cell as covermatter with extra CSS
+    NBPrintCell(section="covermatter", css=":scope { text-align: center; }")
+
+    # Context manager: wrap outputs in a styled <div>
+    with NBPrintCell(style=Style(font=Font(size=24))):
+        display(Markdown("# Cover Page"))
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from IPython.display import display
+from typing_extensions import Self
+
+from nbprint.config.common import Style
+
+__all__ = ("NBPRINT_MIME", "NBPrintCell")
+
+NBPRINT_MIME = "application/nbprint.cell+json"
+
+
+class NBPrintCell:
+    """Runtime helper that emits nbprint cell metadata as a display output.
+
+    Parameters
+    ----------
+    section : str | None
+        Target document section (e.g. ``"covermatter"``, ``"frontmatter"``).
+    css : str | None
+        Raw CSS to merge into the cell.
+    style : Style | None
+        Structured ``Style`` object whose properties are converted to CSS.
+    classname : str | list[str] | None
+        Extra CSS class(es) to add to the cell wrapper.
+    attrs : dict[str, str] | None
+        Extra HTML attributes for the cell wrapper.
+    ignore : bool | None
+        If ``True``, hide the cell in the final output.
+    emit : bool
+        If ``True`` (default), immediately call ``display()`` with the
+        metadata.  Set to ``False`` when used only as a context manager
+        (metadata is emitted on ``__enter__``).
+
+    """
+
+    def __init__(
+        self,
+        *,
+        section: str | None = None,
+        css: str | None = None,
+        style: Style | None = None,
+        classname: str | list[str] | None = None,
+        attrs: dict[str, str] | None = None,
+        ignore: bool | None = None,
+        emit: bool = True,
+    ) -> None:
+        self.section = section
+        self.css = css
+        self.style = style
+        self.classname = classname
+        self.attrs = attrs
+        self.ignore = ignore
+        self._emitted = False
+
+        if emit:
+            self._emit()
+
+    # -- serialisation --------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dict of non-None fields."""
+        d: dict[str, Any] = {}
+        if self.section is not None:
+            d["section"] = self.section
+        if self.css is not None:
+            d["css"] = self.css
+        if self.style is not None:
+            d["style"] = self.style.model_dump(mode="json", exclude_none=True)
+        if self.classname is not None:
+            d["classname"] = self.classname
+        if self.attrs is not None:
+            d["attrs"] = self.attrs
+        if self.ignore is not None:
+            d["ignore"] = self.ignore
+        return d
+
+    # -- display --------------------------------------------------------------
+
+    def _emit(self) -> None:
+        """Publish metadata via IPython ``display()``."""
+        if self._emitted:
+            return
+        data = {NBPRINT_MIME: json.dumps(self.to_dict())}
+        display(data, raw=True)
+        self._emitted = True
+
+    # -- context manager ------------------------------------------------------
+
+    def __enter__(self) -> Self:
+        if not self._emitted:
+            self._emit()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        return None

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -15,8 +15,10 @@ from typing_extensions import Self
 
 from nbprint import __version__
 from nbprint.config.base import BaseModel, Role, _append_or_extend
+from nbprint.config.cell import NBPRINT_MIME
 from nbprint.config.content import Content, ContentCode, ContentMarkdown
 from nbprint.config.exceptions import NBPrintPathIsYamlError, NBPrintPathOrModelMalformedError
+from nbprint.config.magic import _parse_magic_line
 
 from .content import SECTION_ORDER, ContentMarshall
 from .context import Context
@@ -195,6 +197,23 @@ class Configuration(CallableModel, BaseModel):
         else:
             nbprint_cell_meta = {}
 
+        # ── Runtime metadata from NBPrintCell (MIME output) ──────────
+        runtime_meta = Configuration._extract_nbprint_mime(cell)
+        if runtime_meta:
+            for key, value in runtime_meta.items():
+                # Runtime metadata augments but does not overwrite
+                # explicit cell.metadata.nbprint values.
+                nbprint_cell_meta.setdefault(key, value)
+
+        # ── Runtime metadata from %%nbprint magic ────────────────────
+        magic_meta = Configuration._extract_nbprint_magic(source)
+        if magic_meta:
+            for key, value in magic_meta.items():
+                nbprint_cell_meta.setdefault(key, value)
+            # Strip the magic line from the source so the Content
+            # model stores the real code, not the directive.
+            source = "\n".join(source.splitlines()[1:])
+
         # Attach cell tags in to content
         if "tags" in cell["metadata"]:
             nbprint_cell_meta["tags"] = cell["metadata"]["tags"]
@@ -206,7 +225,7 @@ class Configuration(CallableModel, BaseModel):
             return content_model.model_validate(nbprint_cell_meta)
 
         # Set source
-        nbprint_cell_meta["content"] = cell.source
+        nbprint_cell_meta["content"] = source
 
         # Default handling: treat as code or markdown content
         if cell.cell_type == "code":
@@ -217,6 +236,42 @@ class Configuration(CallableModel, BaseModel):
             # Skip, log warning
             _log.warning(f"Unsupported cell type when loading from notebook: {cell.cell_type}")
         return content
+
+    @staticmethod
+    def _extract_nbprint_mime(cell) -> dict | None:
+        """Extract nbprint metadata from a cell's outputs (MIME type output).
+
+        Looks for outputs containing ``application/nbprint.cell+json`` and
+        returns the parsed metadata dict, or ``None``.
+        """
+        import json as _json
+
+        outputs = cell.get("outputs", [])
+        for output in outputs:
+            data = output.get("data", {})
+            if NBPRINT_MIME in data:
+                raw = data[NBPRINT_MIME]
+                if isinstance(raw, str):
+                    return _json.loads(raw)
+                if isinstance(raw, dict):
+                    return raw
+        return None
+
+    @staticmethod
+    def _extract_nbprint_magic(source: str) -> dict | None:
+        """Parse ``%%nbprint key=value ...`` from the first line of source.
+
+        Returns the parsed kwargs dict, or ``None`` if the cell does not
+        start with the magic.
+        """
+        first_line = source.split("\n", 1)[0].strip()
+        if not first_line.startswith("%%nbprint"):
+            return None
+        # Strip the ``%%nbprint`` prefix and parse the rest
+        line = first_line[len("%%nbprint") :].strip()
+        if not line:
+            return {}
+        return _parse_magic_line(line)
 
     @staticmethod
     def _parse_parameters_cell(cell) -> dict:
@@ -285,8 +340,16 @@ class Configuration(CallableModel, BaseModel):
         for cell in cells_to_process:
             cell_instance = Configuration._cell_to_content(cell)
             if cell_instance is not None:
-                # Route cell to the appropriate section based on tags/metadata
+                # Route cell to the appropriate section based on tags/metadata.
+                # Check raw cell metadata/tags first (highest priority).
                 section = Configuration._extract_section_for_cell(cell)
+                # Fall back to runtime metadata: MIME output, then %%nbprint magic.
+                if section is None:
+                    runtime_meta = Configuration._extract_nbprint_mime(cell) or {}
+                    magic_meta = Configuration._extract_nbprint_magic(cell.source.strip()) or {}
+                    runtime_section = runtime_meta.get("section") or magic_meta.get("section")
+                    if runtime_section and runtime_section in SECTION_ORDER:
+                        section = runtime_section
                 target_section = section or "middlematter"
                 getattr(values["content"], target_section).append(cell_instance)
 

--- a/nbprint/config/magic.py
+++ b/nbprint/config/magic.py
@@ -1,0 +1,57 @@
+"""IPython cell magic for annotating cells with nbprint metadata.
+
+Usage inside a notebook cell::
+
+    %%nbprint section=frontmatter css=":scope { font-size: 18px; }"
+    display(Markdown("# Introduction"))
+
+The magic line is parsed as ``key=value`` pairs.  Recognised keys:
+``section``, ``css``, ``classname``, ``ignore``.  The metadata is emitted
+as a custom MIME-type output identical to ``NBPrintCell``.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from IPython.core.magic import Magics, cell_magic, magics_class
+
+from .cell import NBPrintCell
+
+__all__ = ("NBPrintMagics", "load_ipython_extension")
+
+_BOOL_TRUTHY = frozenset({"true", "1", "yes"})
+_BOOL_FALSY = frozenset({"false", "0", "no"})
+
+
+def _parse_magic_line(line: str) -> dict:
+    """Parse ``key=value`` pairs from the magic line."""
+    tokens = shlex.split(line)
+    kwargs: dict = {}
+    for token in tokens:
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key == "ignore":
+            kwargs[key] = value.lower() in _BOOL_TRUTHY
+        else:
+            kwargs[key] = value
+    return kwargs
+
+
+@magics_class
+class NBPrintMagics(Magics):
+    @cell_magic
+    def nbprint(self, line: str, cell: str):  # noqa: ANN201
+        """``%%nbprint`` cell magic — emit nbprint metadata then run cell."""
+        kwargs = _parse_magic_line(line)
+        NBPrintCell(**kwargs)
+        # Execute the rest of the cell
+        self.shell.run_cell(cell)
+
+
+def load_ipython_extension(ipython) -> None:
+    """Register the ``%%nbprint`` magic when loaded as an extension."""
+    ipython.register_magics(NBPrintMagics)

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -739,3 +739,242 @@ class TestPageCounterFields:
     def test_page_counter_style(self):
         p = Page(counter_style="lower-roman")
         assert p.counter_style == "lower-roman"
+
+
+class TestNBPrintCellRuntime:
+    """Phase 6.5 — NBPrintCell runtime API and %%nbprint magic ingestion."""
+
+    def test_nbprint_cell_to_dict(self):
+        """NBPrintCell.to_dict() returns only non-None fields."""
+        from nbprint import NBPrintCell
+
+        cell = NBPrintCell(section="covermatter", css=":scope { color: red; }", emit=False)
+        d = cell.to_dict()
+        assert d == {"section": "covermatter", "css": ":scope { color: red; }"}
+
+    def test_nbprint_cell_to_dict_with_style(self):
+        """NBPrintCell.to_dict() serializes Style objects."""
+        from nbprint import NBPrintCell
+        from nbprint.config.common import Font, Style
+
+        cell = NBPrintCell(style=Style(font=Font(size=24)), emit=False)
+        d = cell.to_dict()
+        assert "style" in d
+        assert d["style"]["font"]["size"] == 24
+
+    def test_nbprint_cell_to_dict_with_all_fields(self):
+        """NBPrintCell.to_dict() includes classname, attrs, ignore."""
+        from nbprint import NBPrintCell
+
+        cell = NBPrintCell(
+            section="frontmatter",
+            css=":scope { margin: 0; }",
+            classname="highlight",
+            attrs={"data-foo": "bar"},
+            ignore=True,
+            emit=False,
+        )
+        d = cell.to_dict()
+        assert d["section"] == "frontmatter"
+        assert d["classname"] == "highlight"
+        assert d["attrs"] == {"data-foo": "bar"}
+        assert d["ignore"] is True
+
+    def test_nbprint_cell_to_dict_empty(self):
+        """NBPrintCell with no args produces empty dict."""
+        from nbprint import NBPrintCell
+
+        cell = NBPrintCell(emit=False)
+        assert cell.to_dict() == {}
+
+    def test_extract_nbprint_mime_from_cell_output(self):
+        """_extract_nbprint_mime finds MIME-type metadata in cell outputs."""
+        import json
+
+        from nbformat.v4 import new_code_cell
+
+        from nbprint import NBPRINT_MIME
+        from nbprint.config.core.config import Configuration
+
+        meta = {"section": "covermatter", "css": ":scope { text-align: center; }"}
+        cell = new_code_cell(
+            source="NBPrintCell(section='covermatter')",
+            metadata={"tags": []},
+        )
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_MIME: json.dumps(meta)},
+                "metadata": {},
+            }
+        ]
+        result = Configuration._extract_nbprint_mime(cell)
+        assert result == meta
+
+    def test_extract_nbprint_mime_missing(self):
+        """_extract_nbprint_mime returns None when no MIME output."""
+        from nbformat.v4 import new_code_cell
+
+        from nbprint.config.core.config import Configuration
+
+        cell = new_code_cell(source="x = 1", metadata={"tags": []})
+        cell.outputs = []
+        assert Configuration._extract_nbprint_mime(cell) is None
+
+    def test_cell_to_content_merges_mime_metadata(self):
+        """_cell_to_content merges MIME output metadata into Content."""
+        import json
+
+        from nbformat.v4 import new_code_cell
+
+        from nbprint import NBPRINT_MIME
+        from nbprint.config.core.config import Configuration
+
+        cell = new_code_cell(
+            source="display('hello')",
+            metadata={"tags": []},
+        )
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_MIME: json.dumps({"css": ":scope { font-size: 2em; }", "classname": "big"})},
+                "metadata": {},
+            }
+        ]
+        content = Configuration._cell_to_content(cell)
+        assert content.css == ":scope { font-size: 2em; }"
+        assert content.classname == "big"
+
+    def test_cell_to_content_metadata_priority_over_mime(self):
+        """Explicit cell.metadata.nbprint takes priority over MIME output."""
+        import json
+
+        from nbformat.v4 import new_code_cell
+
+        from nbprint import NBPRINT_MIME
+        from nbprint.config.core.config import Configuration
+
+        cell = new_code_cell(
+            source="code()",
+            metadata={
+                "tags": [],
+                "nbprint": {"css": "explicit-css"},
+            },
+        )
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_MIME: json.dumps({"css": "mime-css", "classname": "from-mime"})},
+                "metadata": {},
+            }
+        ]
+        content = Configuration._cell_to_content(cell)
+        # Explicit metadata wins for css
+        assert content.css == "explicit-css"
+        # MIME fills in classname since it's not in explicit metadata
+        assert content.classname == "from-mime"
+
+    def test_section_routing_from_mime_output(self):
+        """Cells with section in MIME output are routed to the correct section."""
+        import json
+
+        from nbformat.v4 import new_code_cell, new_notebook
+
+        from nbprint import NBPRINT_MIME
+        from nbprint.config.core.config import Configuration
+
+        nb = new_notebook()
+        cell = new_code_cell(
+            source="display('cover')",
+            metadata={"tags": []},
+        )
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_MIME: json.dumps({"section": "covermatter"})},
+                "metadata": {},
+            }
+        ]
+        nb.cells = [cell]
+
+        values = {"content": ContentMarshall()}
+        Configuration._process_cells(values, nb)
+
+        assert len(values["content"].covermatter) == 1
+        assert len(values["content"].middlematter) == 0
+
+
+class TestNBPrintMagicParsing:
+    """%%nbprint cell magic parsing."""
+
+    def test_extract_magic_basic(self):
+        """_extract_nbprint_magic parses key=value pairs."""
+        from nbprint.config.core.config import Configuration
+
+        result = Configuration._extract_nbprint_magic('%%nbprint section=frontmatter css=":scope { color: red; }"')
+        assert result == {"section": "frontmatter", "css": ":scope { color: red; }"}
+
+    def test_extract_magic_ignore(self):
+        """_extract_nbprint_magic parses ignore as boolean."""
+        from nbprint.config.core.config import Configuration
+
+        result = Configuration._extract_nbprint_magic("%%nbprint ignore=true")
+        assert result == {"ignore": True}
+
+    def test_extract_magic_no_magic(self):
+        """_extract_nbprint_magic returns None for non-magic source."""
+        from nbprint.config.core.config import Configuration
+
+        assert Configuration._extract_nbprint_magic("x = 1") is None
+
+    def test_extract_magic_empty(self):
+        """_extract_nbprint_magic with no args returns empty dict."""
+        from nbprint.config.core.config import Configuration
+
+        result = Configuration._extract_nbprint_magic("%%nbprint")
+        assert result == {}
+
+    def test_cell_to_content_strips_magic_line(self):
+        """_cell_to_content strips the %%nbprint magic line from source."""
+        from nbformat.v4 import new_code_cell
+
+        from nbprint.config.core.config import Configuration
+
+        cell = new_code_cell(
+            source="%%nbprint section=frontmatter\ndisplay('hello')",
+            metadata={"tags": []},
+        )
+        cell.outputs = []
+        content = Configuration._cell_to_content(cell)
+        assert content.content == "display('hello')"
+
+    def test_cell_to_content_magic_sets_section_in_metadata(self):
+        """%%nbprint section= is available for section routing during _process_cells."""
+        from nbformat.v4 import new_code_cell, new_notebook
+
+        from nbprint.config.core.config import Configuration
+
+        nb = new_notebook()
+        nb.cells = [
+            new_code_cell(
+                source="%%nbprint section=endmatter\nresult()",
+                metadata={"tags": []},
+            ),
+        ]
+        # Need to set outputs to empty list
+        nb.cells[0].outputs = []
+
+        values = {"content": ContentMarshall()}
+        Configuration._process_cells(values, nb)
+
+        assert len(values["content"].endmatter) == 1
+        assert values["content"].endmatter[0].content == "result()"
+        assert len(values["content"].middlematter) == 0
+
+    def test_parse_magic_line_quoted_values(self):
+        """_parse_magic_line handles quoted values with spaces."""
+        from nbprint.config.magic import _parse_magic_line
+
+        result = _parse_magic_line('section=frontmatter css=":scope { font-size: 18px; }"')
+        assert result["section"] == "frontmatter"
+        assert result["css"] == ":scope { font-size: 18px; }"


### PR DESCRIPTION
Override break-inside: avoid for content taller than a single page so pagedjs can split it naturally. Previously, tall tables and code blocks were pushed entirely to the next page, leaving the preceding heading alone on the previous page.

- Add allowTallContentToBreak() to preprocessing/measure.js that measures .jp-OutputArea-output elements against the computed page content height and sets break-inside: auto when they exceed it
- Wrap tall code block lines in block-level spans during preprocessing so pagedjs has breakpoints between lines (fixes code-line-integrity)
- Add structural tests: table/code starts on page 1 alongside heading
- Update visual snapshots (content starts on page 1, code blocks now properly span multiple pages)