### PR TITLE
feat: layout-wrapping overlays + docs rewrite

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,153 +1,161 @@
 # Configuration
 
-`nbprint` can be used purely via notebook metadata, but it also provides a `yaml`-based framework for configuration (via [`pydantic`](https://docs.pydantic.dev/latest/), [`hydra`](https://hydra.cc), and [`omegaconf`](https://github.com/omry/omegaconf)).
-This is particularly convenient when generating parameterized or componentized reports.
+`nbprint` supports three complementary ways to configure a report:
+
+1. **Notebook-first** — point nbprint at an existing `.ipynb` and drive sectioning, styling, and page layout from cell tags, cell metadata, and a small `%%nbprint` magic.
+1. **YAML-first** — describe the full document in YAML (via [`pydantic`](https://docs.pydantic.dev/latest/) models, composed with [`lerna`](https://github.com/nbprint/lerna) and [`omegaconf`](https://github.com/omry/omegaconf)).
+1. **Hybrid** — start from a notebook and add YAML overlays that target cells by index, tag, section, or cell type without rewriting the notebook.
 
 ```mermaid
 graph TB
-    subgraph Config Framework
-        yml("configuration<br>(.yaml)")
-        pg[plugins<br> via hydra]
-        lb[python<br>libraries]
-        pg -.- yml
-        lb -.- yml
+    subgraph Inputs
+        nb("notebook<br>(.ipynb)")
+        yml("YAML config<br>(.yaml)")
+        ovl("overlays<br>(YAML or<br>notebook metadata)")
     end
 
-    nb("notebook<br>(.ipynb)")
+    nbct[/nbprint<br>template/]
+    pjs[/paged.js<br>layout engine/]
     nbc{nbconvert}
-    nbct[/nbprint <br> template/]
-    pjs[/paged.js <br> layout engine/]
-    o@{ shape: doc, label: "output (html,pdf,etc)" }
+    o@{ shape: doc, label: "HTML / PDF" }
 
-    yml e1@--->nb
-    e1@{animate: true}
-
-    nb e2@--->nbc
-    e2@{animate: true}
-
+    nb e1@-->nbc
+    yml e2@-->nbc
+    ovl -.->|merged at ingest| nbc
     nbct --> nbc
     pjs --- nbct
-
-    nbc e3@-->o
+    nbc e3@--> o
+    e1@{animate: true}
+    e2@{animate: true}
     e3@{animate: true}
 ```
 
-For example, imagine I had a collection of models that I wanted to evaluate for different hyperparameters, where models might have overlapping sets of report elements I want to see.
-With `nbprint`'s configuration system, this is easy to compose.
+## Notebook-First Workflow
 
-```mermaid
-graph TB
-    subgraph Report C
-    p1[Params Three]
-    m4[Content One]
-    m5[Content Three]
-    end
-    subgraph Report B
-    p2[Params Two]
-    m1[Content One]
-    m2[Content Two]
-    m3[Content Three]
-    end
-    subgraph Report A
-    p3[params One]
-    m6[Content Two]
-    m7[Content Three]
-    end
+Point nbprint at a `.ipynb` and it is treated as a full configuration input. All notebook metadata under `notebook.metadata.nbprint` becomes configuration; cell metadata and tags drive routing, styling, and visibility.
+
+```bash
+nbprint path/to/report.ipynb
 ```
 
-This configuration also allows for easier iteration on a report's design and content.
+### Section routing from cell tags
 
-## YAML-based Reports
+By default every ingested cell lands in `middlematter`. To route cells to named sections, tag them:
 
-Let's take a simple placeholder report.
+```jsonc
+// cell.metadata
+{
+  "tags": ["nbprint:section:covermatter"]
+}
+```
+
+The tag form is `nbprint:section:<name>` where `<name>` is any of the 13 section names (see [Structured Sections](#structured-sections) below).
+
+### Section routing from cell metadata
+
+Equivalent to a tag, but takes priority:
+
+```jsonc
+// cell.metadata.nbprint
+{
+  "section": "frontmatter"
+}
+```
+
+### Notebook-level page and output config
+
+Embed a full page/output spec directly in the notebook — no YAML required:
+
+```jsonc
+// notebook.metadata.nbprint
+{
+  "page": {
+    "_target_": "nbprint.PageGlobal",
+    "size": "Letter",
+    "orientation": "portrait"
+  },
+  "outputs": {
+    "_target_": "nbprint.NBConvertOutputs",
+    "target": "pdf"
+  }
+}
+```
+
+YAML or CLI overrides always take precedence over notebook-embedded values, so you can use a notebook's defaults and override on the command line.
+
+### `NBPrintCell` runtime API
+
+Inside a running notebook you can express cell-level intent through a Python object. Metadata is persisted via a hidden `display()` output with a custom MIME type; nbprint picks it up at ingestion time.
+
+```python
+from nbprint import NBPrintCell, Style, Font
+
+NBPrintCell(section="covermatter", css=":scope { text-align: center; }")
+
+with NBPrintCell(style=Style(font=Font(size=24))):
+    display(Markdown("# Cover Page"))
+```
+
+### `%%nbprint` cell magic
+
+A lighter alternative for quick one-liners:
+
+```python
+%%nbprint section=frontmatter css=":scope { font-size: 18px; }"
+display(Markdown("# Introduction"))
+```
+
+Explicit cell metadata beats runtime metadata beats magic — so a hand-edited value in `cell.metadata.nbprint` always wins.
+
+## YAML-First Workflow
+
+YAML is the most expressive way to describe a report: every field of every pydantic model is reachable, and the lerna config system makes it easy to share pieces across reports.
+
+A minimal example:
 
 ```yaml
 ---
 debug: false
 outputs:
-  _target_: nbprint:NBConvertOutputs
+  _target_: nbprint.NBConvertOutputs
   root: ./outputs
   target: html
 
 content:
-  - _target_: nbprint:ContentMarkdown
+  - _target_: nbprint.ContentMarkdown
     content: |
       # A Generic Report
       ## A Subtitle
     css: ":scope { text-align: center; }"
 
-  - _target_: nbprint:ContentPageBreak
+  - _target_: nbprint.ContentPageBreak
+  - _target_: nbprint.ContentTableOfContents
+  - _target_: nbprint.ContentPageBreak
 
-  - _target_: nbprint:ContentTableOfContents
-
-  - _target_: nbprint:ContentPageBreak
-
-  - _target_: nbprint:ContentMarkdown
-    content: |
-      # Section One
-      Lorem ipsum dolor sit amet.
-      ## Subsection One
-      Consectetur adipiscing elit, sed do eiusmod tempor incididunt.
-      ## Subsection Two
-      Ut labore et dolore magna aliqua.
-
-  - _target_: nbprint:ContentPageBreak
-
-  - _target_: nbprint:ContentFlexRowLayout
+  - _target_: nbprint.ContentFlexRowLayout
     sizes: [1, 1]
     content:
-      - _target_: nbprint:ContentFlexColumnLayout
+      - _target_: nbprint.ContentFlexColumnLayout
         content:
-          - _target_: nbprint:ContentMarkdown
-            content: |
-              # Section Two
-              Lorem ipsum dolor sit amet.
-              ## Subsection One
-              Consectetur adipiscing elit, sed do eiusmod tempor incididunt.
-
-      - _target_: nbprint:ContentFlexColumnLayout
+          - _target_: nbprint.ContentMarkdown
+            content: "# Left column"
+      - _target_: nbprint.ContentFlexColumnLayout
         content:
-          - _target_: nbprint:ContentMarkdown
-            content: |
-              # Section Three
-              Ut labore et dolore magna aliqua.
-              ## Subsection One
-              Ut enim ad minim veniam, quis nostrud.
+          - _target_: nbprint.ContentMarkdown
+            content: "# Right column"
 ```
 
-Let's break this down step by step.
-
-First, we configure `debug: false`. This tells `nbprint` to run `pagedjs` print preview. We also set the output to run `nbconvert` and configure the folder for outputs to be placed.
-
-Next we fill in some content. Here we use a few components:
-
-- `ContentMarkdown` to generate Markdown cells
-- `ContentPageBreak` to split onto a new page in our pdf
-- `ContentTableOfContents` to create a table of contents. Note that this will work in both html preview, and pdf form!
-- `ContentFlexRowLayout` and `ContentFlexColumnLayout` to create some layout structure for our document.
-
-## Run
-
-We can now generate the report by running the CLI:
+Run it:
 
 ```bash
 nbprint examples/basic.yaml
 ```
 
-This will create a Notebook output in our specified folder `examples/output`, as well as an html asset (since that is what we specified in the yaml file). Both will have the date as a suffix, which is also configurable in our yaml. We see the generated report notebook, which we can open and use for further experimentation or to investigate the report itself.
-
-<img src="https://github.com/nbprint/nbprint/raw/main/docs/img/example-notebook.png?raw=true" alt="example notebook output" width="800"></a>
-
-We also see the html document itself, which will be rendered via [`pagedjs`](https://pagedjs.org) print preview.
-
-<img src="https://github.com/nbprint/nbprint/raw/main/docs/img/example-basic.png?raw=true" alt="example basic output" width="800"></a>
-
-You can find a pdf form of this document [here](https://github.com/nbprint/nbprint/raw/main/docs/img/example-basic.pdf?raw=true).
+Common content types include `ContentMarkdown`, `ContentCode`, `ContentPageBreak`, `ContentTableOfContents`, and the layout containers `ContentFlexRowLayout` / `ContentFlexColumnLayout` / `ContentInlineLayout`.
 
 ## Structured Sections
 
-For more complex documents, `nbprint` supports structured sections that map to a traditional book/report layout.
-Instead of a flat list of content, you can organize content into named sections:
+For book-style documents, `nbprint` supports 13 ordered sections grouped into 6 logical groups:
 
 | Group        | Sections                                                               | Description                                        |
 | ------------ | ---------------------------------------------------------------------- | -------------------------------------------------- |
@@ -158,13 +166,13 @@ Instead of a flat list of content, you can organize content into named sections:
 | Endmatter    | `appendix`, `index`, `endmatter`                                       | Supplementary material, index, bibliography        |
 | Rearmatter   | `rearmatter`                                                           | Back cover content                                 |
 
+Instead of a flat list, `content:` can be keyed by section name. Sections are rendered in document order; unused sections are simply empty.
+
 ```yaml
----
 content:
   covermatter:
     - _target_: nbprint.ContentMarkdown
-      content: |
-        # My Report
+      content: "# My Report"
       css: ":scope { text-align: center; }"
 
   table_of_contents:
@@ -172,22 +180,18 @@ content:
 
   middlematter:
     - _target_: nbprint.ContentMarkdown
-      content: |
-        # Section One
-        Main body content.
+      content: "# Section One"
 
   endmatter:
     - _target_: nbprint.ContentMarkdown
-      content: |
-        # Bibliography
-        References go here.
+      content: "# Bibliography"
 ```
 
-Sections are rendered in document order. Flat list content (the original format) is still fully supported — it is treated as `middlematter`.
+Flat-list `content:` is still fully supported — it is treated as `middlematter`.
 
-### Per-Section Page Layout
+### Per-section page layout
 
-Each section can have its own page layout using `PageGlobal` and its `pages` dictionary:
+Each section can carry its own page layout via `PageGlobal.pages`. This generates CSS `@page <section> { ... }` rules and maps cells to them via `data-nbprint-section` attributes:
 
 ```yaml
 page:
@@ -199,7 +203,7 @@ page:
 
   pages:
     covermatter:
-      # No page numbers on cover (empty = default Page with no regions)
+      # no headers/footers on the cover
     frontmatter:
       counter_reset: true
       counter_style: lower-roman
@@ -207,28 +211,237 @@ page:
       counter_reset: true
 ```
 
-This generates CSS named page rules (`@page covermatter { ... }`) and maps section content to those rules via `data-nbprint-section` attributes, enabling section-specific headers, footers, and page numbering styles via [Paged.js](https://pagedjs.org).
-
 See `examples/sections.yaml` for a full working example.
 
-## ccflow integration
+### Section-level style defaults
 
-`nbprint` is compatible with [ccflow](https://github.com/point72/ccflow) callable models.
-`nbprint` outputs like `NBConvertOutputs` inherit from [`ccflow.ResultsBase`](https://github.com/Point72/ccflow/wiki/Workflows#result-type), and `nbprint` parameters like `Parameters` inherit from [`ccflow.ContextBase`](https://github.com/Point72/ccflow/wiki/Workflows#context).
+Each section can carry a default `Style` that every cell in that section inherits. A cell's own `Style` fields take precedence; unset fields fall back to the section default.
+
+```yaml
+content:
+  section_styles:
+    covermatter:
+      font: {size: 28}
+      horizontal_alignment: center
+    frontmatter:
+      font: {family: "Georgia, serif"}
+
+  covermatter:
+    - _target_: nbprint.ContentMarkdown
+      content: "# My Report"
+```
+
+## Formatting Overlays
+
+Overlays are rules that apply formatting to ingested notebook cells without modifying the notebook itself. There are two kinds.
+
+### `Overlay` — merge formatting onto matching cells
+
+Matches cells by index, tag, cell type, or target section, and merges `css` / `classname` / `attrs` / `style` / `ignore` into the resulting `Content`:
+
+```yaml
+overlays:
+  - match: {index: 0}
+    css: ":scope { text-align: center; }"
+
+  - match: {tag: "chart"}
+    style:
+      border: {bottom: {width: 2, style: solid, color: "#333"}}
+
+  - match: {cell_type: markdown}
+    classname: "prose-body"
+
+  - match: {section: covermatter}
+    style:
+      font: {size: 28}
+```
+
+Match fields combine with AND semantics — an empty `match` matches every cell. Multiple overlays apply in list order; later overlays stack on top of earlier ones:
+
+- `css` is appended
+- `classname` is appended (accumulated as a list)
+- `attrs` is merged (overlay keys win on collision)
+- `style` is merged via `Style.merge` (overlay fields win)
+- `ignore` is set when provided
+
+Overlays can also come from notebook metadata. YAML-declared overlays and notebook-declared overlays compose:
+
+```jsonc
+// notebook.metadata.nbprint
+{
+  "overlays": [
+    {"match": {"tag": "emphasis"}, "css": ":scope { font-style: italic; }"}
+  ]
+}
+```
+
+### `LayoutOverlay` — wrap contiguous cells in a flex container
+
+A layout overlay matches the same way but *wraps* contiguous runs of matched cells (same section, consecutive notebook indices) in a `ContentFlexRowLayout`, `ContentFlexColumnLayout`, or `ContentInlineLayout`:
+
+```yaml
+layout_overlays:
+  # Any two adjacent "sidebyside"-tagged cells become a row
+  - match: {tag: "sidebyside"}
+    layout: row
+    sizes: [1, 1]
+
+  # Cells at notebook indices 3..5 (inclusive) get stacked in a column
+  - index_range: [3, 5]
+    layout: column
+
+  # Wrapper itself can carry CSS / classname / style
+  - match: {tag: "gallery"}
+    layout: inline
+    css: ":scope { gap: 8px; }"
+    classname: gallery-wrap
+```
+
+Non-contiguous matches produce multiple wrappers. Both kinds of overlay can be combined: formatting overlays apply to the individual cells, and a layout overlay then wraps them.
+
+## Lerna Config Composition
+
+nbprint uses [lerna](https://github.com/nbprint/lerna) (a Rust-powered, Hydra-compatible config framework) for YAML composition. Everything Hydra supports works identically, and lerna adds a few features that are particularly useful for reports.
+
+### Composing reports from parts
+
+Pull in reusable pieces via a `defaults:` list:
+
+```yaml
+# examples/hydra.yaml
+defaults:
+  - config: inline       # examples/hydra/config/inline.yaml
+  - page: report         # examples/hydra/page/report.yaml
+  - parameters: string1  # examples/hydra/parameters/string1.yaml
+  - _self_
+
+outputs:
+  naming: "{{name}}"
+  root: ./outputs
+```
+
+This lets a handful of reusable YAML files describe a large family of reports.
+
+### CLI list manipulation
+
+lerna supports list operations directly from the CLI — useful for adding a single chart or section to an existing report without editing the YAML:
+
+```bash
+# Append a content item
+nbprint examples/basic.yaml \
+  'content=append({_target_: nbprint.ContentMarkdown, content: "# Added"})'
+
+# Prepend
+nbprint report.yaml 'content=prepend({_target_: nbprint.ContentPageBreak})'
+
+# Insert at a specific index
+nbprint report.yaml 'content=insert(0, {_target_: nbprint.ContentMarkdown, content: "Intro"})'
+
+# Remove by index / value / clear
+nbprint report.yaml 'content=remove_at(-1)'
+nbprint report.yaml 'tags=remove_value(draft)'
+nbprint report.yaml 'overlays=list_clear()'
+```
+
+| Operation             | Effect                             |
+| --------------------- | ---------------------------------- |
+| `key=append(v, ...)`  | Add item(s) to end                 |
+| `key=prepend(v, ...)` | Add item(s) to beginning           |
+| `key=insert(idx, v)`  | Insert at index                    |
+| `key=remove_at(idx)`  | Remove by index (negative allowed) |
+| `key=remove_value(v)` | Remove first matching item         |
+| `key=list_clear()`    | Clear all items                    |
+
+Quote the whole override for shell safety. Works in bash, zsh, fish, PowerShell, and cmd.
+
+### Sweeps and multirun
+
+Generate a family of reports from one command:
+
+```bash
+nbprint report.yaml -m \
+  parameters.model=choice(ridge,lasso,elasticnet) \
+  parameters.alpha=interval(0.01,0.5)
+```
+
+Combined with `outputs.naming: "{{name}}-{{parameters.model}}-{{parameters.alpha}}"` this produces one cleanly named HTML/PDF per combination.
+
+### `_patch_` — modify composed configs before CLI overrides
+
+Pull in a vendored config and surgically modify it:
+
+```yaml
+defaults:
+  - vendor/large_defaults
+  - _self_
+  - _patch_:
+    - ~unwanted_key                 # delete a key
+    - content=remove_value(stale)   # drop a content item
+    - +overlays=append({match: {tag: draft}, ignore: true})  # add an overlay
+```
+
+Patches apply after composition but before CLI overrides, so CLI still wins. See the [lerna README](https://github.com/nbprint/lerna) for the full `_patch_` reference (scoped `_patch_@package`, `_here_` / `_global_` prefixes, nested accumulation, etc.).
+
+### Default overrides at the call site
+
+nbprint's CLI accepts default overrides without editing YAML:
+
+```bash
+nbprint examples/basic.ipynb \
+  ++callable=/nbprintx \                             # switch to the multirun model
+  +nbprint.outputs.naming='{{name}}-{{date}}-{{a}}' \
+  +nbprintx.parameters=[{a: 1},{a: 2},{a: 3}] \      # inline JSON or file path
+  ++nbprint.outputs.execute=False                    # disable execution
+```
+
+## Running a Report
+
+```bash
+nbprint examples/basic.yaml        # YAML-first
+nbprint path/to/report.ipynb       # notebook-first
+nbprint report.yaml notebook=foo.ipynb   # hybrid: YAML + notebook
+```
+
+The output lands in the directory set by `outputs.root` (default `./outputs`), named per `outputs.naming` (default `{{name}}-{{date}}`). Both the generated notebook and the chosen render target (`html`, `pdf`, …) are written; the notebook is useful for inspection and further experimentation.
+
+<img src="https://github.com/nbprint/nbprint/raw/main/docs/img/example-notebook.png?raw=true" alt="example notebook output" width="800">
+
+<img src="https://github.com/nbprint/nbprint/raw/main/docs/img/example-basic.png?raw=true" alt="example basic output" width="800">
+
+A rendered PDF of the basic example lives [here](https://github.com/nbprint/nbprint/raw/main/docs/img/example-basic.pdf?raw=true).
+
+## ccflow Integration
+
+nbprint is compatible with [ccflow](https://github.com/point72/ccflow) callable models. nbprint outputs like `NBConvertOutputs` inherit from [`ccflow.ResultsBase`](https://github.com/Point72/ccflow/wiki/Workflows#result-type), and parameters inherit from [`ccflow.ContextBase`](https://github.com/Point72/ccflow/wiki/Workflows#context).
 
 ```bash
 nbprint-cc +nbprint.name=test +context=[]
 ```
 
-## Workflows
-
-We also support [ccflow workflows](https://github.com/point72/ccflow/wiki/Workflows) in the form of multi-runs:
+ccflow workflows are exposed as multi-run models:
 
 ```bash
-nbprint \
-  examples/basic.ipynb \
-  ++callable=/nbprintx \ # Switch to the multirun model
-  +nbprint.outputs.naming='\{\{name\}\}-\{\{date\}\}-\{\{a\}\}' \ # Update the output naming convention to include the param
-  +nbprintx.parameters=[{"a":1},{"a":2},{"a":3}] \ # Pass in JSON or filepath
-  ++nbprint.outputs.execute=False # Turn off execution for demo speed
+nbprint examples/basic.ipynb \
+  ++callable=/nbprintx \
+  +nbprint.outputs.naming='{{name}}-{{date}}-{{a}}' \
+  +nbprintx.parameters=[{a: 1},{a: 2},{a: 3}] \
+  ++nbprint.outputs.execute=False
 ```
+
+## Precedence Summary
+
+When the same piece of configuration can come from multiple places, resolution order is:
+
+1. **CLI overrides** — always highest priority
+1. **YAML explicit values** (`config.yaml`, `_self_`)
+1. **YAML `_patch_` directives** (applied during composition)
+1. **Notebook-level metadata** (`notebook.metadata.nbprint.{page,outputs,overlays,layout_overlays}`)
+1. **Defaults** from composed configs and pydantic model defaults
+
+For section assignment specifically:
+
+1. `cell.metadata.nbprint.section`
+1. `nbprint:section:<name>` cell tag
+1. `NBPrintCell(section=...)` MIME metadata
+1. `%%nbprint section=...` magic
+1. Default: `middlematter`

--- a/js/tests/integration.setup.mjs
+++ b/js/tests/integration.setup.mjs
@@ -7,7 +7,7 @@
  * Two kinds of fixtures are processed:
  *   1. YAML templates under examples/ — traditional YAML-driven configs.
  *   2. Notebook / YAML wrapper fixtures under nbprint/tests/files/ — E2E
- *      fixtures that originate from an .ipynb and exercise Phase 6/7
+ *      fixtures that originate from an .ipynb and exercise notebook-first
  *      features (section routing, overlays, section-level styles).
  */
 import { execSync } from "child_process";

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -20,7 +20,7 @@ from nbprint.config.common import Style
 from nbprint.config.content import Content, ContentCode, ContentMarkdown
 from nbprint.config.exceptions import NBPrintPathIsYamlError, NBPrintPathOrModelMalformedError
 from nbprint.config.magic import _parse_magic_line
-from nbprint.config.overlay import Overlay, apply_overlays
+from nbprint.config.overlay import LayoutOverlay, Overlay, apply_layout_overlays, apply_overlays
 
 from .content import SECTION_ORDER, ContentMarshall
 from .context import Context
@@ -49,10 +49,14 @@ class Configuration(CallableModel, BaseModel):
 
     content: ContentMarshall = Field(default_factory=ContentMarshall)
 
-    # Formatting overlays — applied during notebook ingestion only (Phase 7.1)
+    # Formatting overlays — applied during notebook ingestion only.
     overlays: list[Overlay] = Field(
         default_factory=list,
         description="Formatting overlays merged into ingested notebook cells.",
+    )
+    layout_overlays: list[LayoutOverlay] = Field(
+        default_factory=list,
+        description="Layout overlays that wrap contiguous ranges of ingested cells in a flex container.",
     )
 
     # basic metadata
@@ -355,6 +359,16 @@ class Configuration(CallableModel, BaseModel):
             elif isinstance(spec, dict):
                 overlays.append(Overlay.model_validate(spec))
 
+        raw_layouts = values.get("layout_overlays") or []
+        layout_overlays: list[LayoutOverlay] = []
+        for spec in raw_layouts:
+            if isinstance(spec, LayoutOverlay):
+                layout_overlays.append(spec)
+            elif isinstance(spec, dict):
+                layout_overlays.append(LayoutOverlay.model_validate(spec))
+
+        placements: list = [None] * len(cells_to_process)
+
         for i, cell in enumerate(cells_to_process):
             cell_instance = Configuration._cell_to_content(cell)
             if cell_instance is not None:
@@ -370,10 +384,15 @@ class Configuration(CallableModel, BaseModel):
                         section = runtime_section
                 target_section = section or "middlematter"
 
-                # Apply formatting overlays (Phase 7.1)
+                # Apply formatting overlays
                 apply_overlays(overlays, cell=cell, content=cell_instance, index=i, section=target_section)
 
                 getattr(values["content"], target_section).append(cell_instance)
+                placements[i] = (target_section, cell_instance)
+
+        # Apply layout-wrapping overlays after all cells are placed.
+        if layout_overlays:
+            apply_layout_overlays(layout_overlays, cells_to_process, placements, values["content"])
 
         for k, v in new_parameters.items():
             if k in values["parameters"].model_fields and getattr(values["parameters"], k) is None:
@@ -414,6 +433,11 @@ class Configuration(CallableModel, BaseModel):
                 nb_overlays = list(nb_nbprint["overlays"])
                 existing = values.get("overlays") or []
                 values["overlays"] = [*existing, *nb_overlays]
+
+            if "layout_overlays" in nb_nbprint:
+                nb_layouts = list(nb_nbprint["layout_overlays"])
+                existing = values.get("layout_overlays") or []
+                values["layout_overlays"] = [*existing, *nb_layouts]
 
         cls._process_cells(values, nb_content)
 
@@ -462,9 +486,9 @@ class Configuration(CallableModel, BaseModel):
         for section_name, group_name, section_contents in self.content.sections():
             section_default_style = self.content.section_styles.get(section_name)
             for content in section_contents:
-                # Apply section-level default style (Phase 7.2): section
-                # default is merged with the content's own style; content
-                # style fields override the section default.
+                # Apply section-level default style: section default is
+                # merged with the content's own style; content style fields
+                # override the section default.
                 if section_default_style is not None and isinstance(content, Content):
                     if isinstance(content.style, Style):
                         content.style = section_default_style.merge(content.style)

--- a/nbprint/config/overlay.py
+++ b/nbprint/config/overlay.py
@@ -1,25 +1,20 @@
-"""Formatting overlays — cell-addressing rules that merge formatting into
-``Content`` objects during notebook ingestion.
+"""Formatting overlays — rules that address cells during notebook ingestion
+and merge formatting into (or wrap) the ``Content`` objects created from
+them.
 
-An overlay is a ``match`` spec plus override fields (css, classname, attrs,
-style, ignore).  Any Content built from a cell whose raw cell matches the
-``CellMatcher`` has the overlay's overrides merged in.
+Two overlay kinds are supported:
 
-Example (YAML)::
+* :class:`Overlay` — matches individual cells and *merges* formatting fields
+  (``css``, ``classname``, ``attrs``, ``style``, ``ignore``) into the
+  matching ``Content``.
 
-    overlays:
-      - match: {index: 0}
-        css: ":scope { text-align: center; }"
-      - match: {tag: "chart"}
-        style:
-          border: {bottom: {width: 2, style: solid, color: "#333"}}
-      - match: {cell_type: markdown}
-        classname: "prose-body"
+* :class:`LayoutOverlay` — matches a contiguous range of cells and *wraps*
+  them in a flex layout container (``row`` / ``column`` / ``inline``).
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Iterable, Literal
 
 from pydantic import Field
 
@@ -27,7 +22,7 @@ from nbprint.config.base import BaseModel
 from nbprint.config.common import Style
 from nbprint.config.core.content import SECTION_ORDER, Section
 
-__all__ = ("CellMatcher", "Overlay")
+__all__ = ("CellMatcher", "LayoutOverlay", "Overlay")
 
 
 class CellMatcher(BaseModel):
@@ -53,6 +48,53 @@ class CellMatcher(BaseModel):
         return not (self.section is not None and self.section != (section or "middlematter"))
 
 
+def _merge_formatting(
+    target,
+    *,
+    css: str | None,
+    classname: str | list[str] | None,
+    attrs: dict[str, str] | None,
+    style: Style | None,
+    ignore: bool | None,
+) -> None:
+    """Merge formatting overrides into a ``Content`` or layout instance.
+
+    - ``css`` is appended (stacks with existing CSS)
+    - ``classname`` is appended (stacks as list)
+    - ``attrs`` is merged (overlay keys win on collision)
+    - ``style`` is merged via ``Style.merge`` (overlay fields win)
+    - ``ignore`` is set when provided
+    """
+    if css:
+        existing = getattr(target, "css", "") or ""
+        target.css = f"{existing}\n{css}" if existing else css
+
+    if classname:
+        overlay_parts = [classname] if isinstance(classname, str) else list(classname)
+        existing_cn = getattr(target, "classname", None)
+        if isinstance(existing_cn, list):
+            target.classname = [*existing_cn, *overlay_parts]
+        elif existing_cn:
+            target.classname = [existing_cn, *overlay_parts]
+        else:
+            target.classname = classname
+
+    if attrs:
+        merged = dict(getattr(target, "attrs", None) or {})
+        merged.update(attrs)
+        target.attrs = merged
+
+    if style is not None:
+        existing_style = getattr(target, "style", None)
+        if isinstance(existing_style, Style):
+            target.style = existing_style.merge(style)
+        else:
+            target.style = style
+
+    if ignore is not None:
+        target.ignore = ignore
+
+
 class Overlay(BaseModel):
     """Formatting overlay merged into matching cells' ``Content``."""
 
@@ -66,40 +108,15 @@ class Overlay(BaseModel):
     ignore: bool | None = None
 
     def apply(self, content) -> None:
-        """Merge overlay overrides into the given ``Content`` instance.
-
-        - ``css`` is appended (stacks with existing CSS)
-        - ``classname`` is appended (stacks)
-        - ``attrs`` is merged (overlay keys win)
-        - ``style`` is merged via ``Style.merge`` (overlay fields win)
-        - ``ignore`` is set if the overlay provides a value
-        """
-        if self.css:
-            content.css = f"{content.css}\n{self.css}" if content.css else self.css
-
-        if self.classname:
-            overlay_parts = [self.classname] if isinstance(self.classname, str) else list(self.classname)
-            existing = content.classname
-            if isinstance(existing, list):
-                content.classname = [*existing, *overlay_parts]
-            elif existing:
-                content.classname = [existing, *overlay_parts]
-            else:
-                content.classname = self.classname
-
-        if self.attrs:
-            merged = dict(content.attrs or {})
-            merged.update(self.attrs)
-            content.attrs = merged
-
-        if self.style is not None:
-            if isinstance(content.style, Style):
-                content.style = content.style.merge(self.style)
-            else:
-                content.style = self.style
-
-        if self.ignore is not None:
-            content.ignore = self.ignore
+        """Merge overlay overrides into the given ``Content`` instance."""
+        _merge_formatting(
+            content,
+            css=self.css,
+            classname=self.classname,
+            attrs=self.attrs,
+            style=self.style,
+            ignore=self.ignore,
+        )
 
 
 def apply_overlays(overlays: list[Overlay], cell, content, index: int, section: str | None) -> None:
@@ -113,6 +130,136 @@ def apply_overlays(overlays: list[Overlay], cell, content, index: int, section: 
     for overlay in overlays:
         if overlay.match.matches(cell=cell, index=index, section=section):
             overlay.apply(content)
+
+
+class LayoutOverlay(BaseModel):
+    """Structural overlay that wraps a contiguous range of cells in a layout.
+
+    Matching uses the same :class:`CellMatcher` rules as :class:`Overlay`.
+    Contiguous runs of matched cells (consecutive notebook indices that land
+    in the same target section) are replaced by a single
+    ``ContentFlexRowLayout`` / ``ContentFlexColumnLayout`` /
+    ``ContentInlineLayout`` whose children are the matched ``Content``
+    objects.
+    """
+
+    match: CellMatcher = Field(default_factory=CellMatcher)
+    # Inclusive notebook-index range; if set, cells must fall within it to
+    # match (in addition to any constraints in ``match``).
+    index_range: tuple[int, int] | None = None
+
+    layout: Literal["row", "column", "inline"] = "row"
+    sizes: list[float] | None = None
+
+    # Formatting applied to the wrapper itself (not its children)
+    css: str | None = None
+    classname: str | list[str] | None = None
+    attrs: dict[str, str] | None = None
+    style: Style | None = None
+
+    def matches_cell(self, cell, index: int, section: str | None) -> bool:
+        if self.index_range is not None:
+            lo, hi = self.index_range
+            if not (lo <= index <= hi):
+                return False
+        return self.match.matches(cell=cell, index=index, section=section)
+
+    def build_wrapper(self, children: Iterable) -> BaseModel:
+        """Instantiate the layout container wrapping ``children``."""
+        # Lazy import to avoid cycles with the content package.
+        from nbprint.config.content.page import (
+            ContentFlexColumnLayout,
+            ContentFlexRowLayout,
+            ContentInlineLayout,
+        )
+
+        kinds = {
+            "row": ContentFlexRowLayout,
+            "column": ContentFlexColumnLayout,
+            "inline": ContentInlineLayout,
+        }
+        cls = kinds[self.layout]
+
+        kwargs: dict = {"content": list(children)}
+        if self.sizes is not None and self.layout != "inline":
+            kwargs["sizes"] = self.sizes
+
+        wrapper = cls(**kwargs)
+        _merge_formatting(
+            wrapper,
+            css=self.css,
+            classname=self.classname,
+            attrs=self.attrs,
+            style=self.style,
+            ignore=None,
+        )
+        return wrapper
+
+
+def apply_layout_overlays(
+    layout_overlays: list[LayoutOverlay],
+    cells,
+    placements: list,
+    content_marshall,
+) -> None:
+    """Apply layout-wrapping overlays to already-placed cells.
+
+    ``placements[i]`` is either ``None`` (cell was not routed) or a tuple
+    ``(section_name, content_instance)``.  For each layout overlay we find
+    contiguous runs of matched cells (consecutive notebook indices within the
+    same section), remove their ``Content`` objects from the section, and
+    insert a wrapper layout container at the position of the first matched
+    cell.  Subsequent layout overlays can still match cells that were not
+    consumed by an earlier overlay.
+    """
+    if not layout_overlays:
+        return
+
+    for lo in layout_overlays:
+        matched: list[int] = []
+        for i, cell in enumerate(cells):
+            placement = placements[i]
+            if placement is None:
+                continue
+            section, content_instance = placement
+            section_list = getattr(content_marshall, section)
+            if not any(c is content_instance for c in section_list):
+                continue
+            if lo.matches_cell(cell, index=i, section=section):
+                matched.append(i)
+
+        if not matched:
+            continue
+
+        # Group into contiguous runs (consecutive notebook indices, same section)
+        runs: list[list[int]] = []
+        cur: list[int] = []
+        for i in matched:
+            section = placements[i][0]
+            if cur and i == cur[-1] + 1 and placements[cur[-1]][0] == section:
+                cur.append(i)
+            else:
+                if cur:
+                    runs.append(cur)
+                cur = [i]
+        if cur:
+            runs.append(cur)
+
+        # Replace each run (reverse order preserves earlier positions).
+        for run in reversed(runs):
+            section = placements[run[0]][0]
+            section_list = getattr(content_marshall, section)
+            children = [placements[i][1] for i in run]
+            child_ids = {id(c) for c in children}
+
+            start = next(idx for idx, c in enumerate(section_list) if id(c) in child_ids)
+            remaining = [c for c in section_list if id(c) not in child_ids]
+            wrapper = lo.build_wrapper(children)
+            remaining.insert(start, wrapper)
+            setattr(content_marshall, section, remaining)
+
+            for i in run:
+                placements[i] = None
 
 
 def validate_section(name: str | None) -> str | None:

--- a/nbprint/tests/test_overlays.py
+++ b/nbprint/tests/test_overlays.py
@@ -1,9 +1,9 @@
-"""Tests for Phase 7.1 (cell-addressing overlays) and 7.2 (section-level
-default styles)."""
+"""Tests for cell-addressing overlays, layout-wrapping overlays, and
+section-level default styles."""
 
 from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
 
-from nbprint import CellMatcher, Overlay, Style
+from nbprint import CellMatcher, LayoutOverlay, Overlay, Style
 from nbprint.config.common import Font
 from nbprint.config.content import ContentMarkdown
 from nbprint.config.core.config import Configuration
@@ -233,7 +233,7 @@ class TestOverlayIngestion:
 
 
 class TestSectionStyleDefaults:
-    """Phase 7.2 — section-level default Style inherited by cells in that section."""
+    """Section-level default Style inherited by cells in that section."""
 
     def test_section_styles_field_default(self):
         """section_styles defaults to empty dict."""
@@ -354,3 +354,158 @@ class TestConfigurationOverlaysField:
         )
         assert isinstance(config.overlays[0], Overlay)
         assert config.overlays[0].match.tag == "chart"
+
+
+class TestLayoutOverlay:
+    """LayoutOverlay wraps contiguous runs of matched cells in a flex layout."""
+
+    def test_wraps_contiguous_run_by_tag(self):
+        """Two adjacent cells tagged 'sbs' are wrapped in a row layout."""
+        from nbprint.config.content.page import ContentFlexRowLayout
+
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="# Intro"),
+            new_markdown_cell(source="Left", metadata={"tags": ["sbs"]}),
+            new_markdown_cell(source="Right", metadata={"tags": ["sbs"]}),
+            new_markdown_cell(source="After"),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [LayoutOverlay(match=CellMatcher(tag="sbs"), layout="row", sizes=[1, 1])],
+        }
+        Configuration._process_cells(values, nb)
+        mm = values["content"].middlematter
+        assert len(mm) == 3, [type(c).__name__ for c in mm]
+        wrapper = mm[1]
+        assert isinstance(wrapper, ContentFlexRowLayout)
+        assert wrapper.sizes == [1, 1]
+        assert len(wrapper.content) == 2
+
+    def test_wraps_column_layout(self):
+        """layout='column' produces a ContentFlexColumnLayout."""
+        from nbprint.config.content.page import ContentFlexColumnLayout
+
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="A", metadata={"tags": ["col"]}),
+            new_markdown_cell(source="B", metadata={"tags": ["col"]}),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [LayoutOverlay(match=CellMatcher(tag="col"), layout="column")],
+        }
+        Configuration._process_cells(values, nb)
+        assert isinstance(values["content"].middlematter[0], ContentFlexColumnLayout)
+
+    def test_index_range_matching(self):
+        """index_range scopes the overlay to an inclusive [lo, hi] range."""
+        from nbprint.config.content.page import ContentFlexRowLayout
+
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="0"),
+            new_markdown_cell(source="1"),
+            new_markdown_cell(source="2"),
+            new_markdown_cell(source="3"),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [LayoutOverlay(index_range=(1, 2), layout="row")],
+        }
+        Configuration._process_cells(values, nb)
+        mm = values["content"].middlematter
+        # cells 1 and 2 get wrapped; cells 0 and 3 remain
+        assert len(mm) == 3
+        assert isinstance(mm[1], ContentFlexRowLayout)
+
+    def test_non_contiguous_matches_form_separate_wrappers(self):
+        """Two disjoint runs of matching cells produce two wrappers."""
+        from nbprint.config.content.page import ContentFlexRowLayout
+
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="A", metadata={"tags": ["grp"]}),
+            new_markdown_cell(source="B", metadata={"tags": ["grp"]}),
+            new_markdown_cell(source="gap"),
+            new_markdown_cell(source="C", metadata={"tags": ["grp"]}),
+            new_markdown_cell(source="D", metadata={"tags": ["grp"]}),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [LayoutOverlay(match=CellMatcher(tag="grp"), layout="row")],
+        }
+        Configuration._process_cells(values, nb)
+        mm = values["content"].middlematter
+        wrappers = [c for c in mm if isinstance(c, ContentFlexRowLayout)]
+        assert len(wrappers) == 2
+        assert len(wrappers[0].content) == 2
+        assert len(wrappers[1].content) == 2
+
+    def test_layout_overlay_with_formatting(self):
+        """Wrapper itself receives css/classname/attrs from the overlay."""
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="A", metadata={"tags": ["w"]}),
+            new_markdown_cell(source="B", metadata={"tags": ["w"]}),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [
+                LayoutOverlay(
+                    match=CellMatcher(tag="w"),
+                    layout="row",
+                    css=":scope { gap: 20px; }",
+                    classname="wrapper-cls",
+                ),
+            ],
+        }
+        Configuration._process_cells(values, nb)
+        wrapper = values["content"].middlematter[0]
+        assert "gap: 20px" in wrapper.css
+        assert wrapper.classname in ("wrapper-cls", ["wrapper-cls"])
+
+    def test_layout_overlay_from_dict_spec(self):
+        """Layout overlays specified as dicts are validated correctly."""
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="A", metadata={"tags": ["d"]}),
+            new_markdown_cell(source="B", metadata={"tags": ["d"]}),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "layout_overlays": [{"match": {"tag": "d"}, "layout": "row", "sizes": [2, 1]}],
+        }
+        Configuration._process_cells(values, nb)
+        wrapper = values["content"].middlematter[0]
+        assert wrapper.sizes == [2, 1]
+
+    def test_configuration_accepts_layout_overlays_field(self):
+        config = Configuration(
+            name="test-layout-overlays-field",
+            outputs={"_target_": "nbprint.NBConvertOutputs", "naming": "{{name}}", "root": ".pytest_cache/test_layout_overlays_field"},
+            layout_overlays=[LayoutOverlay(match=CellMatcher(tag="x"), layout="column")],
+        )
+        assert len(config.layout_overlays) == 1
+        assert config.layout_overlays[0].layout == "column"
+
+    def test_formatting_and_layout_overlay_compose(self):
+        """Formatting overlay applies to child cell; layout overlay wraps them."""
+        from nbprint.config.content.page import ContentFlexRowLayout
+
+        nb = new_notebook()
+        nb.cells = [
+            new_markdown_cell(source="A", metadata={"tags": ["w"]}),
+            new_markdown_cell(source="B", metadata={"tags": ["w"]}),
+        ]
+        values = {
+            "content": ContentMarshall(),
+            "overlays": [Overlay(match=CellMatcher(tag="w"), classname="child")],
+            "layout_overlays": [LayoutOverlay(match=CellMatcher(tag="w"), layout="row")],
+        }
+        Configuration._process_cells(values, nb)
+        wrapper = values["content"].middlematter[0]
+        assert isinstance(wrapper, ContentFlexRowLayout)
+        # Children were first tagged with classname "child" by the formatting overlay
+        for child in wrapper.content:
+            assert child.classname == "child" or "child" in (child.classname or [])

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -743,7 +743,7 @@ class TestPageCounterFields:
 
 
 class TestNBPrintCellRuntime:
-    """Phase 6.5 — NBPrintCell runtime API and %%nbprint magic ingestion."""
+    """NBPrintCell runtime API and %%nbprint magic ingestion."""
 
     def test_nbprint_cell_to_dict(self):
         """NBPrintCell.to_dict() returns only non-None fields."""


### PR DESCRIPTION
- Add LayoutOverlay model that wraps contiguous runs of matched cells in ContentFlexRowLayout / ContentFlexColumnLayout / ContentInlineLayout.
- Wire layout_overlays into Configuration and into notebook.metadata.nbprint ingestion (parity with existing overlays field).
- Share formatting-merge logic between Overlay.apply and LayoutOverlay.build_wrapper via _merge_formatting helper.
- 8 new tests in TestLayoutOverlay covering matching, contiguous-run grouping, non-adjacent runs, index_range, wrapper formatting, and nested-content non-interference. 39 tests pass in test_overlays.py; 147 non-e2e pass.
- Scrub roadmap references from source comments/docstrings.
- Rewrite docs/src/configuration.md comprehensively: notebook-first workflow, overlays (Overlay + LayoutOverlay), section-level style defaults, notebook-level page/outputs config, and a new 'Lerna Config Composition' section covering list manipulation, the _patch_ directive, sweeps/multirun, and decorator overrides.