### PR TITLE
feat(content): ContentPageBox model + NBPrintPage runtime

### DIFF
--- a/nbprint/config/__init__.py
+++ b/nbprint/config/__init__.py
@@ -6,3 +6,4 @@ from .core import *
 from .magic import *
 from .outputs import *
 from .overlay import *
+from .page_runtime import *

--- a/nbprint/config/content/__init__.py
+++ b/nbprint/config/content/__init__.py
@@ -3,5 +3,6 @@ from .common import TextComponent
 from .cover import ContentCover
 from .image import ContentImage
 from .page import *
+from .page_box import ContentPageBox, PageBoxFit
 from .pagebreak import ContentPageBreak
 from .table_of_contents import ContentTableOfContents

--- a/nbprint/config/content/page_box.py
+++ b/nbprint/config/content/page_box.py
@@ -1,0 +1,128 @@
+"""``ContentPageBox`` — a :class:`Content` block representing exactly one logical page.
+
+The page-box is the foundational primitive behind the WYSIWYG authoring
+story (see :class:`nbprint.NBPrintPage`). It is a plain pydantic
+:class:`Content` subclass so every field — including the inherited
+``content`` list of children, ``style``, ``css``, ``classname``,
+``attrs`` — is reachable through hydra/lerna CLI overrides such as::
+
+    +nbprint.content.middlematter[3].fit=strict
+    +nbprint.content.middlematter[3].page_orientation=landscape
+    +nbprint.content.middlematter[3].css=":scope { background: red; }"
+
+No new sectioning semantics are introduced: a ``ContentPageBox`` lives
+inside whatever section owns the cell that produced it.
+
+Key guarantees (enforced by CSS + later JS preprocessing passes):
+
+* A page-box always produces *at least one* page (no blank-page removal
+  sweeps it away — see :mod:`postprocessing/validate.js`).
+* A page-box ends with a hard page break; following content always
+  starts on a fresh page.
+* Overflowing content flows to additional pages — children are never
+  silently dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from IPython.display import HTML
+from pydantic import Field, model_validator
+
+from nbprint.config.common import PageOrientation, PageSize
+
+from .base import Content
+
+__all__ = ("ContentPageBox", "PageBoxFit")
+
+
+PageBoxFit = Literal["scale", "shrink", "strict", "none"]
+
+
+# Default CSS: force page breaks around the box, fill the page vertically
+# so empty or near-empty boxes still render a full page (at-least-one-page
+# guarantee), and allow children to break inside when overflowing to the
+# next page.
+_DEFAULT_PAGE_BOX_CSS = (
+    ":scope {\n"
+    "  break-before: page;\n"
+    "  break-after: page;\n"
+    "  break-inside: auto;\n"
+    "  display: block;\n"
+    "  min-height: var(--pagedjs-pagebox-min-height, 100%);\n"
+    "}\n"
+)
+
+
+class ContentPageBox(Content):
+    """A :class:`Content` block representing a single logical page.
+
+    The box is a regular pydantic model: author it in YAML, override it
+    from the CLI, or produce it at runtime via :class:`NBPrintPage`.
+    """
+
+    fit: PageBoxFit = Field(
+        default="scale",
+        description=(
+            "How to handle content that doesn't fit on one page. "
+            "'scale' (default): shrink scalable children — images, SVGs, "
+            "Plotly charts, tables — to fit; text is never shrunk. "
+            "'shrink': same as 'scale' but with a tighter budget. "
+            "'strict': no scaling; emit a render-time warning on overflow. "
+            "'none': no composite measurement; children flow normally "
+            "but the box still produces break-before/after page."
+        ),
+    )
+
+    # Per-page overrides. When set, Phase 9.9 will emit a named @page
+    # rule and route this box to it. Until that lands these fields
+    # serialize through normally; downstream passes can read them.
+    page_size: PageSize | None = Field(
+        default=None,
+        description="Per-box override for the document page size. Falls back to the global Page.size.",
+    )
+    page_orientation: PageOrientation | None = Field(
+        default=None,
+        description="Per-box override for the document page orientation.",
+    )
+    page_margins: str | None = Field(
+        default=None,
+        description="Per-box override for the document page margins (raw CSS `margin` value).",
+    )
+
+    min_pages: int = Field(
+        default=1,
+        ge=1,
+        description="Minimum number of pages this box must produce. Guaranteed even when the box is empty.",
+    )
+
+    # Inherit ``content: str | list[Content] | None`` from ``Content``.
+    # Runtime (NBPrintPage single-cell) use sets it to the cell source;
+    # YAML use sets it to a list of child ``Content`` models.
+
+    css: str = _DEFAULT_PAGE_BOX_CSS
+
+    @model_validator(mode="after")
+    def _populate_data_attrs(self) -> ContentPageBox:
+        """Seed ``attrs`` and ``tags`` with page-box defaults.
+
+        Values already present in ``attrs`` win (so CLI overrides of
+        ``attrs.data-nbprint-*`` take precedence). Mutates in place to
+        avoid re-triggering ``validate_assignment``.
+        """
+        if "nbprint:content:page-box" not in self.tags:
+            self.tags.append("nbprint:content:page-box")
+        if self.attrs is None:
+            object.__setattr__(self, "attrs", {})
+        attrs = self.attrs  # type: ignore[assignment]
+        attrs.setdefault("data-nbprint-page-box", self._id)
+        attrs["data-nbprint-fit"] = str(self.fit)
+        if self.min_pages > 1:
+            attrs.setdefault("data-nbprint-min-pages", str(self.min_pages))
+        return self
+
+    def __call__(self, **_) -> HTML:
+        # Children are nested into the wrapper by the nbprint runtime
+        # via ``data-nbprint-parent-id``; no source-level HTML needed.
+        return HTML("")

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -21,6 +21,7 @@ from nbprint.config.content import Content, ContentCode, ContentMarkdown
 from nbprint.config.exceptions import NBPrintPathIsYamlError, NBPrintPathOrModelMalformedError
 from nbprint.config.magic import _parse_magic_line
 from nbprint.config.overlay import LayoutOverlay, Overlay, apply_layout_overlays, apply_overlays
+from nbprint.config.page_runtime import NBPRINT_PAGE_MIME
 
 from .content import SECTION_ORDER, ContentMarshall
 from .context import Context
@@ -230,14 +231,18 @@ class Configuration(CallableModel, BaseModel):
         if "tags" in cell["metadata"]:
             nbprint_cell_meta["tags"] = cell["metadata"]["tags"]
 
+        # Ensure source is captured as the content payload. Models that
+        # already declare ``content`` in metadata (e.g. YAML-authored
+        # Content) are left untouched. For runtime-typed cells (e.g.
+        # NBPrintPage emits ``type_=nbprint.ContentPageBox``) the source
+        # becomes the cell body that re-runs on regeneration.
+        nbprint_cell_meta.setdefault("content", source)
+
         # If this is an nbprint defined type, use that
         if "type_" in nbprint_cell_meta:
             content_type = nbprint_cell_meta["type_"]
             content_model = BaseModel._to_type({"type_": content_type}, Content)
             return content_model.model_validate(nbprint_cell_meta)
-
-        # Set source
-        nbprint_cell_meta["content"] = source
 
         # Default handling: treat as code or markdown content
         if cell.cell_type == "code":
@@ -253,20 +258,25 @@ class Configuration(CallableModel, BaseModel):
     def _extract_nbprint_mime(cell) -> dict | None:
         """Extract nbprint metadata from a cell's outputs (MIME type output).
 
-        Looks for outputs containing ``application/nbprint.cell+json`` and
-        returns the parsed metadata dict, or ``None``.
+        Looks for outputs containing any of the nbprint runtime MIME
+        types (``application/nbprint.cell+json``,
+        ``application/nbprint.page+json``) and returns the parsed
+        metadata dict, or ``None``. Both MIME types use the same merge
+        semantics into the cell's nbprint metadata; the kind of model
+        constructed is later driven by the embedded ``type_`` field.
         """
         import json as _json
 
         outputs = cell.get("outputs", [])
         for output in outputs:
             data = output.get("data", {})
-            if NBPRINT_MIME in data:
-                raw = data[NBPRINT_MIME]
-                if isinstance(raw, str):
-                    return _json.loads(raw)
-                if isinstance(raw, dict):
-                    return raw
+            for mime in (NBPRINT_MIME, NBPRINT_PAGE_MIME):
+                if mime in data:
+                    raw = data[mime]
+                    if isinstance(raw, str):
+                        return _json.loads(raw)
+                    if isinstance(raw, dict):
+                        return raw
         return None
 
     @staticmethod

--- a/nbprint/config/page_runtime.py
+++ b/nbprint/config/page_runtime.py
@@ -1,0 +1,160 @@
+"""Runtime API for declaring a WYSIWYG page-box inside a notebook cell.
+
+:class:`NBPrintPage` mirrors :class:`nbprint.NBPrintCell`: it emits a
+hidden ``display()`` output carrying a custom MIME type, which the
+ingestion path converts into a real :class:`ContentPageBox` at load
+time.
+
+Usage (single-cell mode)::
+
+    from nbprint import NBPrintPage
+
+    # Default: shrink scalable children to fit one page; overflow flows.
+    with NBPrintPage():
+        display(summary_table)
+        display(pnl_chart)
+
+    # Landscape override with strict overflow detection
+    with NBPrintPage(page_orientation="landscape", fit="strict"):
+        display(wide_dashboard)
+
+The runtime API is a convenience for notebook authors. A YAML / CLI
+user can author the equivalent :class:`ContentPageBox` directly and
+never invoke ``NBPrintPage``.
+
+Multi-cell mode (wrapping several subsequent cells into one page box)
+is planned for a follow-up task; single-cell wrapping is the MVP.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from IPython.display import display
+from typing_extensions import Self
+
+from nbprint.config.common import PageOrientation, PageSize, Style
+from nbprint.config.content.page_box import PageBoxFit
+
+__all__ = ("NBPRINT_PAGE_MIME", "NBPrintPage")
+
+NBPRINT_PAGE_MIME = "application/nbprint.page+json"
+
+# Fully qualified target path used by ingestion to construct the right
+# Content subclass. Kept here to avoid an import-time circular.
+_PAGE_BOX_TYPE = "nbprint.ContentPageBox"
+
+
+class NBPrintPage:
+    """Runtime helper that marks the current cell as a ``ContentPageBox``.
+
+    Parameters
+    ----------
+    section : str | None
+        Target document section (e.g. ``"covermatter"``). Routed through
+        the same mechanism as :class:`NBPrintCell`.
+    fit : {"scale", "shrink", "strict", "none"}
+        How to handle overflow. See :class:`ContentPageBox` for details.
+    page_size : PageSize | str | None
+        Per-box override of the document page size.
+    page_orientation : PageOrientation | str | None
+        Per-box override of the document page orientation.
+    page_margins : str | None
+        Per-box override of the document page margins (raw CSS value).
+    min_pages : int
+        Minimum number of pages this box produces. Default ``1``.
+    css : str | None
+        Extra CSS to merge into the box (e.g. background, padding).
+    style : Style | None
+        Structured ``Style`` object merged into the box's style.
+    classname : str | list[str] | None
+        Extra CSS class(es) for the box wrapper.
+    attrs : dict[str, str] | None
+        Extra HTML attributes for the box wrapper.
+    ignore : bool | None
+        If ``True``, hide the box from the final output.
+    emit : bool
+        If ``True`` (default) immediately publish the metadata via
+        ``display()``. Set to ``False`` when you only want to use the
+        object as a context manager; metadata is emitted on ``__enter__``.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        section: str | None = None,
+        fit: PageBoxFit = "scale",
+        page_size: PageSize | str | None = None,
+        page_orientation: PageOrientation | str | None = None,
+        page_margins: str | None = None,
+        min_pages: int = 1,
+        css: str | None = None,
+        style: Style | None = None,
+        classname: str | list[str] | None = None,
+        attrs: dict[str, str] | None = None,
+        ignore: bool | None = None,
+        emit: bool = True,
+    ) -> None:
+        self.section = section
+        self.fit = fit
+        self.page_size = page_size
+        self.page_orientation = page_orientation
+        self.page_margins = page_margins
+        self.min_pages = min_pages
+        self.css = css
+        self.style = style
+        self.classname = classname
+        self.attrs = attrs
+        self.ignore = ignore
+        self._emitted = False
+
+        if emit:
+            self._emit()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serializable dict of fields to merge into the cell model.
+
+        Always includes ``type_`` so the ingestion path constructs a
+        :class:`ContentPageBox` rather than a plain :class:`Content`.
+        """
+        d: dict[str, Any] = {
+            "type_": _PAGE_BOX_TYPE,
+            "fit": self.fit,
+            "min_pages": self.min_pages,
+        }
+        if self.section is not None:
+            d["section"] = self.section
+        if self.page_size is not None:
+            d["page_size"] = str(self.page_size)
+        if self.page_orientation is not None:
+            d["page_orientation"] = str(self.page_orientation)
+        if self.page_margins is not None:
+            d["page_margins"] = self.page_margins
+        if self.css is not None:
+            d["css"] = self.css
+        if self.style is not None:
+            d["style"] = self.style.model_dump(mode="json", exclude_none=True)
+        if self.classname is not None:
+            d["classname"] = self.classname
+        if self.attrs is not None:
+            d["attrs"] = self.attrs
+        if self.ignore is not None:
+            d["ignore"] = self.ignore
+        return d
+
+    def _emit(self) -> None:
+        if self._emitted:
+            return
+        data = {NBPRINT_PAGE_MIME: json.dumps(self.to_dict())}
+        display(data, raw=True)
+        self._emitted = True
+
+    def __enter__(self) -> Self:
+        if not self._emitted:
+            self._emit()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        return None

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -1043,3 +1043,217 @@ class TestNBPrintMagicParsing:
         result = _parse_magic_line('section=frontmatter css=":scope { font-size: 18px; }"')
         assert result["section"] == "frontmatter"
         assert result["css"] == ":scope { font-size: 18px; }"
+
+
+class TestContentPageBox:
+    """Phase 9.1 — ContentPageBox model."""
+
+    def test_defaults(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox()
+        assert box.fit == "scale"
+        assert box.min_pages == 1
+        assert box.page_size is None
+        assert box.page_orientation is None
+        assert box.page_margins is None
+        assert "nbprint:content:page-box" in box.tags
+
+    def test_default_css_has_page_breaks(self):
+        from nbprint.config.content import ContentPageBox
+
+        css = ContentPageBox().css
+        assert "break-before: page" in css
+        assert "break-after: page" in css
+        assert ":scope" in css
+
+    def test_data_attrs_populated(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox()
+        assert box.attrs["data-nbprint-page-box"] == box._id
+        assert box.attrs["data-nbprint-fit"] == "scale"
+        # min_pages default (1) does NOT add data-nbprint-min-pages
+        assert "data-nbprint-min-pages" not in box.attrs
+
+    def test_fit_override_reflected_in_attrs(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(fit="strict")
+        assert box.fit == "strict"
+        assert box.attrs["data-nbprint-fit"] == "strict"
+
+    def test_min_pages_attr_set_when_greater_than_one(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(min_pages=3)
+        assert box.attrs["data-nbprint-min-pages"] == "3"
+
+    def test_user_attrs_preserved(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(attrs={"data-custom": "x", "data-nbprint-page-box": "override"})
+        # User override of the data-nbprint-page-box wins (setdefault).
+        assert box.attrs["data-nbprint-page-box"] == "override"
+        assert box.attrs["data-custom"] == "x"
+
+    def test_page_overrides(self):
+        from nbprint.config.common import PageOrientation, PageSize
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(
+            page_size=PageSize.A4,
+            page_orientation=PageOrientation.landscape,
+            page_margins="1in",
+        )
+        assert box.page_size == PageSize.A4
+        assert box.page_orientation == PageOrientation.landscape
+        assert box.page_margins == "1in"
+
+    def test_min_pages_validation(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from nbprint.config.content import ContentPageBox
+
+        with pytest.raises(ValidationError):
+            ContentPageBox(min_pages=0)
+
+    def test_accepts_children(self):
+        from nbprint.config.content import ContentMarkdown, ContentPageBox
+
+        box = ContentPageBox(content=[ContentMarkdown(content="# hi")])
+        assert isinstance(box.content, list)
+        assert len(box.content) == 1
+
+    def test_is_content_subclass(self):
+        from nbprint.config.content import Content, ContentPageBox
+
+        assert issubclass(ContentPageBox, Content)
+
+    def test_top_level_export(self):
+        import nbprint
+
+        assert hasattr(nbprint, "ContentPageBox")
+
+
+class TestNBPrintPage:
+    """Phase 9.2 — NBPrintPage runtime API."""
+
+    def test_top_level_export(self):
+        import nbprint
+
+        assert hasattr(nbprint, "NBPrintPage")
+        assert hasattr(nbprint, "NBPRINT_PAGE_MIME")
+
+    def test_to_dict_emits_type(self):
+        from nbprint import NBPrintPage
+
+        page = NBPrintPage(emit=False)
+        d = page.to_dict()
+        assert d["type_"] == "nbprint.ContentPageBox"
+        assert d["fit"] == "scale"
+        assert d["min_pages"] == 1
+
+    def test_to_dict_omits_none_fields(self):
+        from nbprint import NBPrintPage
+
+        d = NBPrintPage(emit=False).to_dict()
+        for key in ("section", "page_size", "page_orientation", "page_margins", "css", "style", "classname", "attrs", "ignore"):
+            assert key not in d
+
+    def test_to_dict_includes_overrides(self):
+        from nbprint import NBPrintPage
+
+        page = NBPrintPage(
+            emit=False,
+            section="covermatter",
+            fit="strict",
+            page_size="A4",
+            page_orientation="landscape",
+            page_margins="1in",
+            min_pages=2,
+            css=":scope { background: red; }",
+            classname="hero",
+            attrs={"data-test": "1"},
+            ignore=False,
+        )
+        d = page.to_dict()
+        assert d["section"] == "covermatter"
+        assert d["fit"] == "strict"
+        assert d["page_size"] == "A4"
+        assert d["page_orientation"] == "landscape"
+        assert d["page_margins"] == "1in"
+        assert d["min_pages"] == 2
+        assert d["css"] == ":scope { background: red; }"
+        assert d["classname"] == "hero"
+        assert d["attrs"] == {"data-test": "1"}
+        assert d["ignore"] is False
+
+    def test_emit_publishes_mime(self):
+        from unittest.mock import patch
+
+        from nbprint import NBPRINT_PAGE_MIME, NBPrintPage
+
+        with patch("nbprint.config.page_runtime.display") as mock_display:
+            NBPrintPage(fit="shrink")
+            assert mock_display.call_count == 1
+            args, kwargs = mock_display.call_args
+            data = args[0]
+            assert NBPRINT_PAGE_MIME in data
+            assert kwargs == {"raw": True}
+
+    def test_context_manager_emits_once(self):
+        from unittest.mock import patch
+
+        from nbprint import NBPrintPage
+
+        with patch("nbprint.config.page_runtime.display") as mock_display:
+            page = NBPrintPage(emit=False)
+            assert mock_display.call_count == 0
+            with page:
+                pass
+            assert mock_display.call_count == 1
+            # Re-entering should not re-emit.
+            with page:
+                pass
+            assert mock_display.call_count == 1
+
+    def test_ingestion_produces_page_box(self):
+        """Runtime MIME output builds a ContentPageBox in Configuration ingestion."""
+        import json
+
+        from nbformat.v4 import new_code_cell, new_notebook
+
+        from nbprint import NBPRINT_PAGE_MIME
+        from nbprint.config.content import ContentPageBox
+        from nbprint.config.core.config import Configuration
+
+        nb = new_notebook()
+        cell = new_code_cell(source="display('chart')", metadata={"tags": []})
+        payload = {
+            "type_": "nbprint.ContentPageBox",
+            "fit": "strict",
+            "min_pages": 2,
+            "page_orientation": "landscape",
+        }
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_PAGE_MIME: json.dumps(payload)},
+                "metadata": {},
+            }
+        ]
+        nb.cells = [cell]
+
+        values = {"content": ContentMarshall()}
+        Configuration._process_cells(values, nb)
+
+        assert len(values["content"].middlematter) == 1
+        box = values["content"].middlematter[0]
+        assert isinstance(box, ContentPageBox)
+        assert box.fit == "strict"
+        assert box.min_pages == 2
+        assert str(box.page_orientation) == "landscape"
+        # Source is preserved as the box's content.
+        assert box.content == "display('chart')"


### PR DESCRIPTION
Introduce the page-box primitive that underlies WYSIWYG authoring:

- ContentPageBox: plain Content subclass with fit, page_size, page_orientation, page_margins, and min_pages fields. Emits hard page breaks and guarantees at least one page. Every field is a standard pydantic attribute so hydra/lerna CLI overrides compose naturally (e.g. +nbprint.content.middlematter[3].fit=strict).
- NBPrintPage: runtime context manager that emits a new MIME type (application/nbprint.page+json) carrying the ContentPageBox type target so ingestion builds the right model with zero special-casing.
- Tests: 18 new cases covering defaults, CSS, data-attr injection, override precedence, runtime MIME emission, context-manager semantics, and round-trip ingestion.

Source-of-truth capture: _cell_to_content now setdefault()s the cell source as 'content' before the type_ branch so runtime-typed cells preserve their source for regeneration.
