### PR TITLE
feat(content): ContentPageBlock primitive

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -236,6 +236,69 @@ Content that is executed as a Markdown cell.
 - `ContentFlexRowLayout`
 - `ContentPageBreak`
 
+#### Page-box primitives
+
+The page-box primitives (Phase 9.1 / 9.3) are first-class `Content`
+models for WYSIWYG, page-level authoring. Both are plain pydantic
+classes so every field is reachable from a hydra/lerna CLI override
+such as `+nbprint.content.middlematter[3].fit=strict`.
+
+##### `ContentPageBox`
+
+A single logical page. Always emits at least one page (even when
+empty), forces a `break-before` and `break-after`, and exposes
+per-page overrides for `page_size`, `page_orientation`, and
+`page_margins`. Children flow inside it as page-blocks; overflow
+spills onto additional pages without dropping content.
+
+Key fields: `fit` (`scale` / `shrink` / `strict` / `none`),
+`min_pages`, `page_size`, `page_orientation`, `page_margins`. Emits
+`data-nbprint-page-box`, `data-nbprint-fit`, and (when overridden)
+`data-nbprint-min-pages` for downstream JS measurement and CSS
+targeting.
+
+##### `ContentPageBlock`
+
+The atomic layout item inside a `ContentPageBox`. Defaults to
+`break-inside: avoid` so each block is a "keep together" unit.
+Supports grid placement (`span`, `rows`, `area`), aspect-ratio and
+height constraints (`aspect`, `min_height`, `max_height`), and an
+explicit `scalable` hint that the page-box's `fit` pass will respect
+when shrinking content to fit.
+
+Per-instance values are emitted both as discoverable
+`data-nbprint-*` attributes (for JS measurement and CSS attribute
+selectors) and as inline `style=` rules so they win over any preset
+CSS from the parent page-box. User-supplied `attrs.style` is
+preserved and appended after the generated rules.
+
+```yaml
+# YAML usage inside a ContentPageBox
+content:
+  middlematter:
+    - type_: nbprint.ContentPageBox
+      fit: scale
+      content:
+        - type_: nbprint.ContentPageBlock
+          span: 2
+          aspect: "16:9"
+          content:
+            - type_: nbprint.ContentImage
+              src: hero.png
+        - type_: nbprint.ContentPageBlock
+          break_inside: auto       # this one is allowed to flow
+          content:
+            - type_: nbprint.ContentMarkdown
+              content: "Long narrative text..."
+```
+
+```bash
+# Hydra CLI override of a single block's span
+nbprint examples/research.yaml \
+    '+nbprint.content.middlematter[0].content[0].span=3' \
+    '+nbprint.content.middlematter[0].content[0].aspect=1.7777'
+```
+
 #### Library Configuration Elements
 
 - `LoggingConfig`

--- a/js/tests/fixtures/page_block/basic.html
+++ b/js/tests/fixtures/page_block/basic.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBlock — basic</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic the wrapper a ContentPageBlock receives from the nbprint
+   template: a jp-Cell carrying the data-nbprint-block attribute, the
+   inline `style` produced by ContentPageBlock._populate_block_metadata,
+   and (for grid-positioned variants) the data-nbprint-span etc. */
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-block="block-default"
+       data-nbprint-break-inside="avoid"
+       style="break-inside: avoid">
+    <div class="jp-Cell-outputWrapper">
+      <div class="jp-OutputArea jp-Cell-outputArea">
+        <div class="jp-OutputArea-output jp-RenderedHTMLCommon">
+          <h2>Default block</h2>
+          <p>Break-inside: avoid by default. Should stay together on one page.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="jp-Cell"
+       data-nbprint-block="block-spanned"
+       data-nbprint-break-inside="avoid"
+       data-nbprint-span="2"
+       style="break-inside: avoid; grid-column: span 2">
+    <div class="jp-Cell-outputWrapper">
+      <div class="jp-OutputArea jp-Cell-outputArea">
+        <div class="jp-OutputArea-output jp-RenderedHTMLCommon">
+          <h2>Spanned block</h2>
+          <p>Carries data-nbprint-span="2" and grid-column: span 2 inline.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="jp-Cell"
+       data-nbprint-block="block-aspect"
+       data-nbprint-break-inside="avoid"
+       style="break-inside: avoid; aspect-ratio: 16/9; min-height: 2in">
+    <div class="jp-Cell-outputWrapper">
+      <div class="jp-OutputArea jp-Cell-outputArea">
+        <div class="jp-OutputArea-output jp-RenderedHTMLCommon">
+          <h2>Aspect-ratio block</h2>
+          <p>16:9 aspect, min-height 2in.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/page_block.spec.js
+++ b/js/tests/page_block.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+// Helper: wait for pagedjs to finish rendering.
+async function waitForPagedJS(page, timeout = 30000) {
+  await page.waitForSelector(".pagedjs_pages", { timeout });
+  await page.waitForTimeout(500);
+}
+
+async function getPages(page) {
+  return page.locator(".pagedjs_page").all();
+}
+
+test.describe("ContentPageBlock — Phase 9.3", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_block/basic.html");
+    await waitForPagedJS(page);
+  });
+
+  test("renders at least one page", async ({ page }) => {
+    const pages = await getPages(page);
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  test("data-nbprint-block attribute survives pagination", async ({ page }) => {
+    // Paged.js clones source content into pagedjs_page_content; assert the
+    // attribute appears in the rendered DOM.
+    const blocks = await page.locator("[data-nbprint-block]").all();
+    expect(blocks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("default block carries break-inside: avoid", async ({ page }) => {
+    const block = page.locator('[data-nbprint-block="block-default"]').first();
+    const breakInside = await block.evaluate(
+      (el) => getComputedStyle(el).breakInside,
+    );
+    expect(breakInside).toBe("avoid");
+  });
+
+  test("spanned block reflects data-nbprint-span", async ({ page }) => {
+    const block = page.locator('[data-nbprint-block="block-spanned"]').first();
+    const span = await block.getAttribute("data-nbprint-span");
+    expect(span).toBe("2");
+  });
+
+  test("aspect block applies aspect-ratio", async ({ page }) => {
+    const block = page.locator('[data-nbprint-block="block-aspect"]').first();
+    const aspect = await block.evaluate(
+      (el) => getComputedStyle(el).aspectRatio,
+    );
+    // Browsers normalize "16/9" to "16 / 9".
+    expect(aspect.replace(/\s+/g, "")).toBe("16/9");
+  });
+
+  test("blocks do not overflow page width", async ({ page }) => {
+    const pages = await getPages(page);
+    for (const pageEl of pages) {
+      const pageBox = await pageEl.boundingBox();
+      const blocks = await pageEl.locator("[data-nbprint-block]").all();
+      for (const block of blocks) {
+        const box = await block.boundingBox();
+        if (box && pageBox) {
+          expect(box.x + box.width).toBeLessThanOrEqual(
+            pageBox.x + pageBox.width + 1,
+          );
+        }
+      }
+    }
+  });
+});

--- a/nbprint/config/content/__init__.py
+++ b/nbprint/config/content/__init__.py
@@ -3,6 +3,7 @@ from .common import TextComponent
 from .cover import ContentCover
 from .image import ContentImage
 from .page import *
+from .page_block import BreakInside, ContentPageBlock
 from .page_box import ContentPageBox, PageBoxFit
 from .pagebreak import ContentPageBreak
 from .table_of_contents import ContentTableOfContents

--- a/nbprint/config/content/page_block.py
+++ b/nbprint/config/content/page_block.py
@@ -1,0 +1,204 @@
+"""``ContentPageBlock`` — the atomic layout item inside a :class:`ContentPageBox`.
+
+A page-block is the unit a layout-aware page-box arranges. It is *not*
+a layout container itself — that role is filled by
+:class:`ContentFlexRowLayout`, :class:`ContentFlexColumnLayout`,
+:class:`ContentInlineLayout`, and (forthcoming in Phase 9.4) the
+``layout`` field on :class:`ContentPageBox`.
+
+Use cases:
+
+* Inside an ``NBPrintPage``: the page-box auto-wraps bare children in
+  blocks (Phase 9.4) so every direct child of a page-box is a block.
+  Authors who want to escape the auto-placement (e.g. "this hero spans
+  both columns") instantiate a block explicitly with ``span=2``.
+* Standalone (outside a page-box): the block's default
+  ``break-inside: avoid`` makes it a useful "keep together"
+  primitive for long-scroll reports.
+
+Like :class:`ContentPageBox`, every field is a plain pydantic
+attribute so hydra/lerna CLI overrides compose naturally::
+
+    +nbprint.content.middlematter[0].content[2].span=2
+    +nbprint.content.middlematter[0].content[2].aspect=1.7777
+    +nbprint.content.middlematter[0].content[2].area=hero
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from IPython.display import HTML
+from pydantic import Field, model_validator
+
+from .base import Content
+
+__all__ = ("BreakInside", "ContentPageBlock")
+
+
+BreakInside = Literal["avoid", "auto"]
+
+
+# Universal block CSS:
+#   * min-width/min-height: 0 — required so flex/grid items can shrink
+#     below their intrinsic content size (otherwise grid columns blow
+#     out their tracks). This is a well-known grid/flex footgun.
+#   * display: block — explicit, so the wrapper participates in flow
+#     even when its content is inline.
+# Per-instance values (break-inside, span, rows, area, aspect,
+# min/max-height) are emitted as inline ``style=`` attributes via
+# ``attrs`` so they apply with element-level specificity and override
+# any preset CSS from the parent page-box.
+_DEFAULT_PAGE_BLOCK_CSS = ":scope {\n  min-width: 0;\n  min-height: 0;\n  display: block;\n}\n"
+
+
+def _format_aspect(value: float | str) -> str:
+    """Normalize an ``aspect`` value into a CSS ``aspect-ratio`` string.
+
+    Accepts:
+
+    * ``float`` / ``int`` (e.g. ``1.7777``, ``16/9`` evaluated by Python)
+    * ``"W:H"`` (e.g. ``"16:9"``) — the Pythonic shorthand.
+    * Any other string — passed through verbatim, so authors can use the
+      raw CSS forms ``"16/9"``, ``"16 / 9"``, or ``"auto 1 / 1"``.
+    """
+    if isinstance(value, (int, float)):
+        return repr(float(value))
+    if ":" in value:
+        w, _, h = value.partition(":")
+        return f"{w.strip()}/{h.strip()}"
+    return value
+
+
+class ContentPageBlock(Content):
+    """A single layout item inside a :class:`ContentPageBox`.
+
+    The block owns its own break behavior, optional grid positioning,
+    and an optional aspect-ratio constraint. It does not itself produce
+    a page break, never owns ``@page`` rules, and never measures its
+    children — that's the page-box's job.
+    """
+
+    # ── Grid / column placement ──────────────────────────────────────
+    span: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Number of columns to span when the parent page-box uses a "
+            "grid or columns layout. Maps to CSS `grid-column: span N`. "
+            "``None`` means 1 column (auto-placement)."
+        ),
+    )
+    rows: int | None = Field(
+        default=None,
+        ge=1,
+        description=("Number of rows to span in a grid layout. Maps to CSS `grid-row: span N`. ``None`` means 1 row."),
+    )
+    area: str | None = Field(
+        default=None,
+        description=("Named grid area for use with ``ContentPageBox.layout='grid'`` and ``grid_template`` (Phase 9.5). Maps to CSS `grid-area`."),
+    )
+
+    # ── Sizing constraints ───────────────────────────────────────────
+    aspect: float | str | None = Field(
+        default=None,
+        description=(
+            "Aspect ratio constraint. Accepts a float (``1.7777``), a "
+            "Pythonic shorthand (``'16:9'``), or a raw CSS value "
+            "(``'16/9'``). Maps to CSS `aspect-ratio`."
+        ),
+    )
+    min_height: str | None = Field(
+        default=None,
+        description="Optional CSS `min-height` for the block (e.g. `'4in'`).",
+    )
+    max_height: str | None = Field(
+        default=None,
+        description="Optional CSS `max-height` for the block (e.g. `'8in'`).",
+    )
+
+    # ── Pagination behavior ──────────────────────────────────────────
+    break_inside: BreakInside = Field(
+        default="avoid",
+        description=(
+            "CSS `break-inside` value. Default ``'avoid'`` keeps the "
+            "block together on one page; set to ``'auto'`` to allow "
+            "splitting (e.g. for long tables that should flow)."
+        ),
+    )
+
+    # ── Measurement / scaling hints (consumed in 9.7 / 9.8) ──────────
+    scalable: bool | None = Field(
+        default=None,
+        description=(
+            "Whether this block's content can be proportionally shrunk "
+            "by the page-box's `fit` pass. ``None`` (default) means "
+            "auto-detect at render from the child output MIME types: "
+            "True for images/SVGs/Plotly/tables, False for "
+            "text/markdown/code. Set explicitly to override."
+        ),
+    )
+
+    css: str = _DEFAULT_PAGE_BLOCK_CSS
+
+    @model_validator(mode="after")
+    def _populate_block_metadata(self) -> ContentPageBlock:
+        """Seed ``tags`` and ``attrs`` with block defaults.
+
+        Builds the inline ``style`` attribute from the per-instance
+        sizing/placement fields. User-supplied ``style=`` in ``attrs``
+        wins (we prepend, then preserve the user value).
+
+        Mutates in place to avoid re-triggering ``validate_assignment``.
+        """
+        if "nbprint:content:page-block" not in self.tags:
+            self.tags.append("nbprint:content:page-block")
+
+        if self.attrs is None:
+            object.__setattr__(self, "attrs", {})
+        attrs = self.attrs  # type: ignore[assignment]
+
+        # Discoverable data attributes — used by JS measurement passes
+        # (9.7 / 9.8) and visual regression tests, and stable for
+        # CSS attribute-selector targeting.
+        attrs.setdefault("data-nbprint-block", self._id)
+        attrs["data-nbprint-break-inside"] = self.break_inside
+        if self.span is not None:
+            attrs["data-nbprint-span"] = str(self.span)
+        if self.rows is not None:
+            attrs["data-nbprint-rows"] = str(self.rows)
+        if self.area is not None:
+            attrs["data-nbprint-area"] = self.area
+        if self.scalable is not None:
+            attrs["data-nbprint-scalable"] = "true" if self.scalable else "false"
+
+        # Inline style — element-level specificity beats any page-box
+        # preset CSS, so a per-block override always wins.
+        rules: list[str] = [f"break-inside: {self.break_inside}"]
+        if self.span is not None:
+            rules.append(f"grid-column: span {self.span}")
+        if self.rows is not None:
+            rules.append(f"grid-row: span {self.rows}")
+        if self.area is not None:
+            rules.append(f"grid-area: {self.area}")
+        if self.aspect is not None:
+            rules.append(f"aspect-ratio: {_format_aspect(self.aspect)}")
+        if self.min_height is not None:
+            rules.append(f"min-height: {self.min_height}")
+        if self.max_height is not None:
+            rules.append(f"max-height: {self.max_height}")
+        block_style = "; ".join(rules)
+
+        # Preserve any user-supplied style by prepending ours.
+        existing = attrs.get("style", "")
+        if existing:
+            attrs["style"] = f"{block_style}; {existing}"
+        else:
+            attrs["style"] = block_style
+
+        return self
+
+    def __call__(self, **_) -> HTML:
+        # Children nest into the wrapper via ``data-nbprint-parent-id``;
+        # no source-level HTML required.
+        return HTML("")

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -1257,3 +1257,150 @@ class TestNBPrintPage:
         assert str(box.page_orientation) == "landscape"
         # Source is preserved as the box's content.
         assert box.content == "display('chart')"
+
+
+class TestContentPageBlock:
+    """Phase 9.3 — ContentPageBlock primitive."""
+
+    def test_defaults(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock()
+        assert block.span is None
+        assert block.rows is None
+        assert block.area is None
+        assert block.aspect is None
+        assert block.min_height is None
+        assert block.max_height is None
+        assert block.break_inside == "avoid"
+        assert block.scalable is None
+        assert "nbprint:content:page-block" in block.tags
+
+    def test_default_css(self):
+        from nbprint.config.content import ContentPageBlock
+
+        css = ContentPageBlock().css
+        assert ":scope" in css
+        assert "min-width: 0" in css
+        assert "min-height: 0" in css
+
+    def test_data_attrs_populated_with_id(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock()
+        assert block.attrs["data-nbprint-block"] == block._id
+        assert block.attrs["data-nbprint-break-inside"] == "avoid"
+        # Optional placement attrs absent by default.
+        for absent in ("data-nbprint-span", "data-nbprint-rows", "data-nbprint-area", "data-nbprint-scalable"):
+            assert absent not in block.attrs
+
+    def test_span_attr_and_inline_style(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(span=2)
+        assert block.attrs["data-nbprint-span"] == "2"
+        assert "grid-column: span 2" in block.attrs["style"]
+
+    def test_rows_attr_and_inline_style(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(rows=3)
+        assert block.attrs["data-nbprint-rows"] == "3"
+        assert "grid-row: span 3" in block.attrs["style"]
+
+    def test_area_attr_and_inline_style(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(area="hero")
+        assert block.attrs["data-nbprint-area"] == "hero"
+        assert "grid-area: hero" in block.attrs["style"]
+
+    def test_aspect_float(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(aspect=1.7777)
+        assert "aspect-ratio: 1.7777" in block.attrs["style"]
+
+    def test_aspect_string_colon(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(aspect="16:9")
+        assert "aspect-ratio: 16/9" in block.attrs["style"]
+
+    def test_aspect_string_passthrough(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(aspect="16/9")
+        assert "aspect-ratio: 16/9" in block.attrs["style"]
+
+    def test_break_inside_default_avoid(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock()
+        assert "break-inside: avoid" in block.attrs["style"]
+        assert block.attrs["data-nbprint-break-inside"] == "avoid"
+
+    def test_break_inside_override(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(break_inside="auto")
+        assert block.break_inside == "auto"
+        assert block.attrs["data-nbprint-break-inside"] == "auto"
+        assert "break-inside: auto" in block.attrs["style"]
+
+    def test_min_max_height_emitted(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(min_height="2in", max_height="6in")
+        assert "min-height: 2in" in block.attrs["style"]
+        assert "max-height: 6in" in block.attrs["style"]
+
+    def test_scalable_attr(self):
+        from nbprint.config.content import ContentPageBlock
+
+        true_block = ContentPageBlock(scalable=True)
+        false_block = ContentPageBlock(scalable=False)
+        assert true_block.attrs["data-nbprint-scalable"] == "true"
+        assert false_block.attrs["data-nbprint-scalable"] == "false"
+
+    def test_user_attrs_preserved_block_id(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(attrs={"data-nbprint-block": "override", "data-custom": "x"})
+        # User's data-nbprint-block wins (setdefault).
+        assert block.attrs["data-nbprint-block"] == "override"
+        assert block.attrs["data-custom"] == "x"
+
+    def test_user_style_preserved(self):
+        from nbprint.config.content import ContentPageBlock
+
+        block = ContentPageBlock(span=2, attrs={"style": "color: red"})
+        # User style is appended after our generated style.
+        assert "grid-column: span 2" in block.attrs["style"]
+        assert "color: red" in block.attrs["style"]
+
+    def test_span_validation(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from nbprint.config.content import ContentPageBlock
+
+        with pytest.raises(ValidationError):
+            ContentPageBlock(span=0)
+
+    def test_is_content_subclass(self):
+        from nbprint.config.content import Content, ContentPageBlock
+
+        assert issubclass(ContentPageBlock, Content)
+
+    def test_top_level_export(self):
+        import nbprint
+
+        assert hasattr(nbprint, "ContentPageBlock")
+
+    def test_accepts_children(self):
+        from nbprint.config.content import ContentMarkdown, ContentPageBlock
+
+        block = ContentPageBlock(content=[ContentMarkdown(content="# hi")])
+        assert isinstance(block.content, list)
+        assert len(block.content) == 1


### PR DESCRIPTION
Add ContentPageBlock — the atomic layout item inside a ContentPageBox. Plain pydantic Content subclass so every field composes with hydra/lerna CLI overrides like
'+nbprint.content.middlematter[0].content[2].span=2'.

Fields:
  * span / rows / area  — grid placement
  * aspect              — float, 'W:H', or raw CSS aspect-ratio
  * min_height / max_height
  * break_inside        — default 'avoid' (keep-together)
  * scalable            — hint for the page-box fit pass

Per-instance values are emitted both as data-nbprint-* attributes (for JS measurement and CSS attribute selectors) and as inline style= rules so they win over any preset CSS from the parent page-box. User-supplied attrs.style is preserved.

Tests:
  * 19 unit tests in nbprint/tests/test_sections.py (TestContentPageBlock) — defaults, CSS, data attrs, span/rows/ area, aspect float + 'W:H' + raw, break-inside override, min/max height, scalable, user-attr precedence, validation, Content subclass, top-level export, accepts children.
  * 6 Playwright structural tests in js/tests/page_block.spec.js
    + fixture js/tests/fixtures/page_block/basic.html — verifies the block survives pagination, computed break-inside is 'avoid', span attribute persists, aspect-ratio applies, no overflow.

Docs:
  * docs/src/architecture.md — new 'Page-box primitives' subsection documenting ContentPageBox + ContentPageBlock with YAML and hydra-CLI examples.
