### PR TITLE
feat(content): ContentPageBox layout presets, auto-wrap, named-area grids, NBPrintBlock runtime

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -266,19 +266,19 @@ blocks. Each preset emits the corresponding CSS on `:scope`; they
 share constants with the existing flex/inline layout containers so
 there is one source of truth for "what does `display: flex` mean."
 
-| `layout`      | CSS emitted                                                  | Use for                                  |
-| ------------- | ------------------------------------------------------------ | ---------------------------------------- |
-| `flow`        | normal block flow (`gap` → `margin-top` between siblings)    | default — long-form content              |
-| `columns-2/3` | `column-count: N; column-fill: balance`                      | newspaper-style multi-column layouts     |
-| `grid-2x2`    | `display: grid; grid-template-columns: repeat(2, 1fr)`       | 4-cell dashboards                        |
-| `grid-3x2`    | `display: grid; grid-template-columns: repeat(3, 1fr)`       | 6-cell dashboards                        |
-| `grid-3x3`    | `display: grid; grid-template-columns: repeat(3, 1fr)`       | 9-cell mosaics                           |
-| `grid`        | bare `display: grid` for named-area templates (Phase 9.5)    | custom grids with `grid_template`        |
-| `flex-row`    | `display: flex; flex-direction: row` (shared with `ContentFlexRowLayout`)    | side-by-side panels |
-| `flex-column` | `display: flex; flex-direction: column` (shared with `ContentFlexColumnLayout`) | stacked panels with gap |
-| `inline`      | `display: block` + per-sibling `margin-left` for `gap`       | header/badge rows                        |
-| `masonry`     | `display: grid; grid-template-rows: masonry` (+ JS polyfill, Phase 9.17) | tile galleries                |
-| `custom`      | suppresses preset CSS — user owns `:scope` via `css`         | full manual control                      |
+| `layout`      | CSS emitted                                                                     | Use for                              |
+| ------------- | ------------------------------------------------------------------------------- | ------------------------------------ |
+| `flow`        | normal block flow (`gap` → `margin-top` between siblings)                       | default — long-form content          |
+| `columns-2/3` | `column-count: N; column-fill: balance`                                         | newspaper-style multi-column layouts |
+| `grid-2x2`    | `display: grid; grid-template-columns: repeat(2, 1fr)`                          | 4-cell dashboards                    |
+| `grid-3x2`    | `display: grid; grid-template-columns: repeat(3, 1fr)`                          | 6-cell dashboards                    |
+| `grid-3x3`    | `display: grid; grid-template-columns: repeat(3, 1fr)`                          | 9-cell mosaics                       |
+| `grid`        | bare `display: grid` for named-area templates (Phase 9.5)                       | custom grids with `grid_template`    |
+| `flex-row`    | `display: flex; flex-direction: row` (shared with `ContentFlexRowLayout`)       | side-by-side panels                  |
+| `flex-column` | `display: flex; flex-direction: column` (shared with `ContentFlexColumnLayout`) | stacked panels with gap              |
+| `inline`      | `display: block` + per-sibling `margin-left` for `gap`                          | header/badge rows                    |
+| `masonry`     | `display: grid; grid-template-rows: masonry` (+ JS polyfill, Phase 9.17)        | tile galleries                       |
+| `custom`      | suppresses preset CSS — user owns `:scope` via `css`                            | full manual control                  |
 
 `gap`, `padding`, `align`, `justify` are passed to whichever preset
 makes sense for them; they are no-ops for presets that don't apply
@@ -316,6 +316,32 @@ content:
 nbprint examples/research.yaml \
     '+nbprint.content.middlematter[2].layout=grid-3x2' \
     '+nbprint.content.middlematter[2].gap=0.5in'
+```
+
+###### Named-area grids (`grid_template`)
+
+When `layout="grid"`, set `grid_template` to a raw CSS
+`grid-template` value to lay out children by name. Each child block
+references a cell via `area=`; the page-box validator cross-checks
+that every referenced area exists in the template (unused template
+areas are allowed — they just produce empty cells). The `.`
+placeholder is treated as an empty cell, not an area name.
+
+```yaml
+- type_: nbprint.ContentPageBox
+  layout: grid
+  grid_template: "'hero hero' 'chart table' / 1fr 1fr"
+  gap: 0.25in
+  content:
+    - type_: nbprint.ContentPageBlock
+      area: hero
+      content: [...]
+    - type_: nbprint.ContentPageBlock
+      area: chart
+      content: [...]
+    - type_: nbprint.ContentPageBlock
+      area: table
+      content: [...]
 ```
 
 ##### `ContentPageBlock`
@@ -359,6 +385,43 @@ nbprint examples/research.yaml \
     '+nbprint.content.middlematter[0].content[0].span=3' \
     '+nbprint.content.middlematter[0].content[0].aspect=1.7777'
 ```
+
+##### Runtime API: `NBPrintPage` and `NBPrintBlock`
+
+`ContentPageBox` and `ContentPageBlock` can also be authored from
+inside a notebook via the matching runtime context managers, which
+emit hidden `application/nbprint.page+json` /
+`application/nbprint.block+json` MIME outputs. The ingestion path
+extracts those payloads and routes them through the same
+`type_`-aware machinery that handles YAML — there is no separate
+runtime path.
+
+```python
+from IPython.display import display
+from nbprint import NBPrintPage, NBPrintBlock
+
+# A landscape dashboard page split into a hero + 2 mid + 1 footer.
+with NBPrintPage(
+    layout="grid",
+    grid_template="'hero hero' 'chart table' 'footer footer' / 1fr 1fr",
+    page_orientation="landscape",
+    fit="scale",
+    gap="0.25in",
+):
+    with NBPrintBlock(area="hero"):
+        display(banner_image)
+    with NBPrintBlock(area="chart", aspect="16:9"):
+        display(revenue_chart)
+    with NBPrintBlock(area="table", break_inside="auto"):
+        display(deals_table)  # allowed to flow if it overflows
+    with NBPrintBlock(area="footer"):
+        display(disclaimer_md)
+```
+
+Both context managers accept every field of their corresponding
+`Content` model. Outside a `ContentPageBox`, `NBPrintBlock` still
+applies — `break_inside: avoid` is a useful "keep together"
+primitive even in long-scroll reports.
 
 #### Library Configuration Elements
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -252,10 +252,71 @@ per-page overrides for `page_size`, `page_orientation`, and
 spills onto additional pages without dropping content.
 
 Key fields: `fit` (`scale` / `shrink` / `strict` / `none`),
-`min_pages`, `page_size`, `page_orientation`, `page_margins`. Emits
-`data-nbprint-page-box`, `data-nbprint-fit`, and (when overridden)
+`min_pages`, `page_size`, `page_orientation`, `page_margins`,
+`layout`, `gap`, `padding`, `align`, `justify`. Emits
+`data-nbprint-page-box`, `data-nbprint-fit`,
+`data-nbprint-layout`, and (when overridden)
 `data-nbprint-min-pages` for downstream JS measurement and CSS
 targeting.
+
+###### Layout presets
+
+`ContentPageBox.layout` selects a built-in arrangement for child
+blocks. Each preset emits the corresponding CSS on `:scope`; they
+share constants with the existing flex/inline layout containers so
+there is one source of truth for "what does `display: flex` mean."
+
+| `layout`      | CSS emitted                                                  | Use for                                  |
+| ------------- | ------------------------------------------------------------ | ---------------------------------------- |
+| `flow`        | normal block flow (`gap` → `margin-top` between siblings)    | default — long-form content              |
+| `columns-2/3` | `column-count: N; column-fill: balance`                      | newspaper-style multi-column layouts     |
+| `grid-2x2`    | `display: grid; grid-template-columns: repeat(2, 1fr)`       | 4-cell dashboards                        |
+| `grid-3x2`    | `display: grid; grid-template-columns: repeat(3, 1fr)`       | 6-cell dashboards                        |
+| `grid-3x3`    | `display: grid; grid-template-columns: repeat(3, 1fr)`       | 9-cell mosaics                           |
+| `grid`        | bare `display: grid` for named-area templates (Phase 9.5)    | custom grids with `grid_template`        |
+| `flex-row`    | `display: flex; flex-direction: row` (shared with `ContentFlexRowLayout`)    | side-by-side panels |
+| `flex-column` | `display: flex; flex-direction: column` (shared with `ContentFlexColumnLayout`) | stacked panels with gap |
+| `inline`      | `display: block` + per-sibling `margin-left` for `gap`       | header/badge rows                        |
+| `masonry`     | `display: grid; grid-template-rows: masonry` (+ JS polyfill, Phase 9.17) | tile galleries                |
+| `custom`      | suppresses preset CSS — user owns `:scope` via `css`         | full manual control                      |
+
+`gap`, `padding`, `align`, `justify` are passed to whichever preset
+makes sense for them; they are no-ops for presets that don't apply
+(e.g. `align` on `flow`).
+
+Crucially, the page-box runs an **auto-wrap validator**: any bare
+child `Content` inside its `content` list is wrapped in a
+`ContentPageBlock` so the DOM shape is always
+`page-box > block > <user content>`. Authors who want to escape
+auto-placement (e.g. "this hero spans both columns") write the
+block explicitly.
+
+```yaml
+content:
+  middlematter:
+    - type_: nbprint.ContentPageBox
+      layout: grid-2x2
+      gap: 0.25in
+      content:
+        # auto-wrapped — no explicit ContentPageBlock needed
+        - type_: nbprint.ContentMarkdown
+          content: "## Quarter highlights"
+        - type_: nbprint.ContentImage
+          src: revenue.png
+        # explicit block to span both columns
+        - type_: nbprint.ContentPageBlock
+          span: 2
+          content:
+            - type_: nbprint.ContentImage
+              src: hero.png
+```
+
+```bash
+# Hydra CLI override switches a page-box from flow to a 3-column grid
+nbprint examples/research.yaml \
+    '+nbprint.content.middlematter[2].layout=grid-3x2' \
+    '+nbprint.content.middlematter[2].gap=0.5in'
+```
 
 ##### `ContentPageBlock`
 

--- a/js/tests/fixtures/page_box/columns-2.html
+++ b/js/tests/fixtures/page_box/columns-2.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=columns-2</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic the CSS that ContentPageBox(layout="columns-2", gap="0.5in")
+   emits via build_page_box_css(). */
+[data-nbprint-page-box="box-cols"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: block;
+  min-height: 100%;
+  column-count: 2;
+  column-fill: balance;
+  column-gap: 0.5in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-cols"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="columns-2">
+    <div class="jp-Cell" data-nbprint-block="b1" data-nbprint-break-inside="avoid">
+      <h2>Block 1</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Quisque ut metus sed nibh dapibus aliquet. Aenean a tortor ac
+      neque condimentum dictum. Nulla facilisi.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="b2" data-nbprint-break-inside="avoid">
+      <h2>Block 2</h2>
+      <p>Phasellus auctor, mauris a tincidunt egestas, neque erat
+      hendrerit risus, vitae rhoncus turpis nibh nec lectus.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="b3" data-nbprint-break-inside="avoid">
+      <h2>Block 3</h2>
+      <p>Sed posuere consectetur est at lobortis. Cras justo odio,
+      dapibus ac facilisis in, egestas eget quam.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="b4" data-nbprint-break-inside="avoid">
+      <h2>Block 4</h2>
+      <p>Donec ullamcorper nulla non metus auctor fringilla. Maecenas
+      sed diam eget risus varius blandit sit amet non magna.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/grid-2x2.html
+++ b/js/tests/fixtures/page_box/grid-2x2.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=grid-2x2</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="grid-2x2", gap="0.25in"). */
+[data-nbprint-page-box="box-grid"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: grid;
+  min-height: 100%;
+  grid-auto-flow: row dense;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.25in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+  border: 1px dashed #999;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-grid"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="grid-2x2">
+    <div class="jp-Cell" data-nbprint-block="g1" data-nbprint-break-inside="avoid">
+      <h2>Cell 1,1</h2>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="g2" data-nbprint-break-inside="avoid">
+      <h2>Cell 1,2</h2>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="g3" data-nbprint-break-inside="avoid"
+         data-nbprint-span="2" style="grid-column: span 2">
+      <h2>Cell 2 spanning both columns</h2>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="g4" data-nbprint-break-inside="avoid">
+      <h2>Cell 3,1</h2>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/named-areas.html
+++ b/js/tests/fixtures/page_box/named-areas.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fixture: ContentPageBox layout=grid + grid_template</title>
+    <script>
+      var _nbprint_configuration = {
+        pagedjs: true,
+        debug: false,
+        page: '{"orientation": null, "size": null}',
+      };
+      var _nbprint_notebook_info = new Map();
+      window.FontAwesomeConfig = { searchPseudoElements: true };
+    </script>
+    <script type="module" src="/js/dist/embedded.js"></script>
+    <link rel="stylesheet" href="/js/dist/css/embedded.css" />
+    <link rel="stylesheet" href="/js/dist/css/index.css" />
+    <style>
+      body.jp-Notebook {
+        margin: 0;
+        padding: 0 !important;
+      }
+      @page {
+        margin: 0.5in;
+      }
+      /* Mimic ContentPageBox(layout="grid",
+   grid_template="'hero hero' 'chart table' / 1fr 1fr",
+   gap="0.25in"). */
+      [data-nbprint-page-box="box-areas"] {
+        break-before: page;
+        break-after: page;
+        break-inside: auto;
+        display: grid;
+        min-height: 100%;
+        grid-auto-flow: row dense;
+        gap: 0.25in;
+        grid-template: "hero hero" "chart table" / 1fr 1fr;
+      }
+      [data-nbprint-block] {
+        break-inside: avoid;
+        min-width: 0;
+        min-height: 0;
+        border: 1px solid #555;
+        padding: 0.5rem;
+        font-family: sans-serif;
+      }
+      [data-nbprint-area="hero"] {
+        background: #d0e6ff;
+        min-height: 1.5in;
+      }
+      [data-nbprint-area="chart"] {
+        background: #e6f5d0;
+        min-height: 3in;
+      }
+      [data-nbprint-area="table"] {
+        background: #fff1c2;
+        min-height: 3in;
+      }
+    </style>
+  </head>
+  <body
+    class="jp-Notebook"
+    data-jp-theme-light="true"
+    data-jp-theme-name="JupyterLab Light"
+  >
+    <main>
+      <div
+        class="jp-Cell"
+        data-nbprint-page-box="box-areas"
+        data-nbprint-fit="scale"
+        data-nbprint-layout="grid"
+      >
+        <div
+          class="jp-Cell"
+          data-nbprint-block="b-hero"
+          data-nbprint-area="hero"
+          data-nbprint-break-inside="avoid"
+          style="grid-area: hero"
+        >
+          <h2>Hero (spans both columns)</h2>
+        </div>
+        <div
+          class="jp-Cell"
+          data-nbprint-block="b-chart"
+          data-nbprint-area="chart"
+          data-nbprint-break-inside="avoid"
+          style="grid-area: chart"
+        >
+          <h3>Chart</h3>
+        </div>
+        <div
+          class="jp-Cell"
+          data-nbprint-block="b-table"
+          data-nbprint-area="table"
+          data-nbprint-break-inside="avoid"
+          style="grid-area: table"
+        >
+          <h3>Table</h3>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/js/tests/page_box.spec.js
+++ b/js/tests/page_box.spec.js
@@ -87,4 +87,44 @@ test.describe("ContentPageBox layout presets — Phase 9.4", () => {
       expect(spannedBox.width).toBeGreaterThan(siblingBox.width * 1.5);
     });
   });
+
+  test.describe("layout=grid + grid_template (named areas)", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/named-areas.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("hero area spans the full width", async ({ page }) => {
+      const hero = page.locator('[data-nbprint-block="b-hero"]').first();
+      const chart = page.locator('[data-nbprint-block="b-chart"]').first();
+      const heroBox = await hero.boundingBox();
+      const chartBox = await chart.boundingBox();
+      // Hero area covers both columns -> roughly 2x the chart width.
+      expect(heroBox.width).toBeGreaterThan(chartBox.width * 1.5);
+    });
+
+    test("chart and table sit side by side", async ({ page }) => {
+      const chart = page.locator('[data-nbprint-block="b-chart"]').first();
+      const table = page.locator('[data-nbprint-block="b-table"]').first();
+      const chartBox = await chart.boundingBox();
+      const tableBox = await table.boundingBox();
+      // Same row → similar y, table is to the right of chart.
+      expect(Math.abs(chartBox.y - tableBox.y)).toBeLessThan(5);
+      expect(tableBox.x).toBeGreaterThan(chartBox.x);
+    });
+
+    test("data-nbprint-area attributes survive pagination", async ({
+      page,
+    }) => {
+      for (const area of ["hero", "chart", "table"]) {
+        const el = page.locator(`[data-nbprint-area="${area}"]`).first();
+        await expect(el).toHaveAttribute("data-nbprint-area", area);
+      }
+    });
+  });
 });

--- a/js/tests/page_box.spec.js
+++ b/js/tests/page_box.spec.js
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+
+async function waitForPagedJS(page, timeout = 30000) {
+  await page.waitForSelector(".pagedjs_pages", { timeout });
+  await page.waitForTimeout(500);
+}
+
+async function getPages(page) {
+  return page.locator(".pagedjs_page").all();
+}
+
+test.describe("ContentPageBox layout presets — Phase 9.4", () => {
+  test.describe("layout=columns-2", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/columns-2.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box reflects layout attribute", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-cols"]').first();
+      await expect(box).toHaveAttribute("data-nbprint-layout", "columns-2");
+    });
+
+    test("computed column-count is 2", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-cols"]').first();
+      const count = await box.evaluate(
+        (el) => getComputedStyle(el).columnCount,
+      );
+      expect(count).toBe("2");
+    });
+
+    test("blocks survive pagination with break-inside avoid", async ({
+      page,
+    }) => {
+      const blocks = await page.locator("[data-nbprint-block]").all();
+      expect(blocks.length).toBeGreaterThanOrEqual(4);
+      for (const block of blocks) {
+        const breakInside = await block.evaluate(
+          (el) => getComputedStyle(el).breakInside,
+        );
+        expect(breakInside).toBe("avoid");
+      }
+    });
+  });
+
+  test.describe("layout=grid-2x2", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/grid-2x2.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box uses display: grid", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-grid"]').first();
+      const display = await box.evaluate((el) => getComputedStyle(el).display);
+      expect(display).toBe("grid");
+    });
+
+    test("grid-template-columns has two equal tracks", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-grid"]').first();
+      const tracks = await box.evaluate(
+        (el) => getComputedStyle(el).gridTemplateColumns,
+      );
+      // Browsers resolve "repeat(2, 1fr)" to two pixel widths separated
+      // by a space — assert exactly two tokens.
+      expect(tracks.split(/\s+/).filter(Boolean).length).toBe(2);
+    });
+
+    test("spanned block occupies both columns", async ({ page }) => {
+      const spanned = page.locator('[data-nbprint-block="g3"]').first();
+      const span = await spanned.getAttribute("data-nbprint-span");
+      expect(span).toBe("2");
+      // Width should be (roughly) the same as the page-box's content area,
+      // i.e. wider than its non-spanning siblings.
+      const spannedBox = await spanned.boundingBox();
+      const sibling = page.locator('[data-nbprint-block="g1"]').first();
+      const siblingBox = await sibling.boundingBox();
+      expect(spannedBox.width).toBeGreaterThan(siblingBox.width * 1.5);
+    });
+  });
+});

--- a/js/tests/visual.spec.js
+++ b/js/tests/visual.spec.js
@@ -106,6 +106,46 @@ const TEMPLATES = [
   "greattables",
 ];
 
+test.describe("Visual regression — page-box layout fixtures", () => {
+  test("columns-2 layout", async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_box/columns-2.html");
+    await waitForPagedJS(page);
+    const count = await screenshotPages(
+      page,
+      test.info(),
+      "page-box-columns-2",
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("grid-2x2 layout", async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_box/grid-2x2.html");
+    await waitForPagedJS(page);
+    const count = await screenshotPages(page, test.info(), "page-box-grid-2x2");
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("named-area grid (grid_template)", async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_box/named-areas.html");
+    await waitForPagedJS(page);
+    const count = await screenshotPages(
+      page,
+      test.info(),
+      "page-box-named-areas",
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+test.describe("Visual regression — page-block fixtures", () => {
+  test("basic blocks", async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_block/basic.html");
+    await waitForPagedJS(page);
+    const count = await screenshotPages(page, test.info(), "page-block-basic");
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
 test.describe("Visual regression — report outputs", () => {
   // Report outputs can be large (many pages), so allow more time
   test.describe.configure({ timeout: 120_000 });

--- a/js/tests/visual.spec.js-snapshots/page-block-basic-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/page-block-basic-page-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1cce8d2e3ae43386e64abfcddf87ce7a35c517f642ae1a9b56d0f85c05fc3b7
+size 24480

--- a/js/tests/visual.spec.js-snapshots/page-box-columns-2-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/page-box-columns-2-page-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee075f322ec78b55ed73c0070821c1070da3df5cbbda16be92e8b52268f9ca15
+size 42061

--- a/js/tests/visual.spec.js-snapshots/page-box-grid-2x2-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/page-box-grid-2x2-page-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79a9b5871968df6bd9dc5cfe025553adc57140ce242985978a7595125b23e25d
+size 14873

--- a/js/tests/visual.spec.js-snapshots/page-box-named-areas-page-1.png
+++ b/js/tests/visual.spec.js-snapshots/page-box-named-areas-page-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02739999e25dc4774d385c0dd1878b0a6c8224b816e1034e5c359159d3383547
+size 12106

--- a/nbprint/config/__init__.py
+++ b/nbprint/config/__init__.py
@@ -1,4 +1,5 @@
 from .base import *
+from .block_runtime import *
 from .cell import *
 from .common import *
 from .content import *

--- a/nbprint/config/block_runtime.py
+++ b/nbprint/config/block_runtime.py
@@ -1,0 +1,181 @@
+"""Runtime API for declaring a WYSIWYG page-block inside a notebook cell.
+
+:class:`NBPrintBlock` mirrors :class:`NBPrintPage`: it emits a hidden
+``display()`` output carrying ``application/nbprint.block+json``,
+which the ingestion path converts into a real
+:class:`ContentPageBlock` at load time.
+
+Usage (single-cell mode)::
+
+    from nbprint import NBPrintBlock
+
+    # Span 2 columns of a parent grid layout
+    with NBPrintBlock(span=2, aspect="16:9"):
+        display(hero_chart)
+
+    # "Keep together" primitive — useful even outside a page-box
+    with NBPrintBlock(break_inside="avoid"):
+        display(summary_table)
+
+    # Allow long content to flow across pages
+    with NBPrintBlock(break_inside="auto"):
+        display(very_long_dataframe)
+
+The runtime API is a notebook-author convenience. A YAML / CLI user
+can author the equivalent :class:`ContentPageBlock` directly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from IPython.display import display
+from typing_extensions import Self
+
+from nbprint.config.common import Style
+from nbprint.config.content.page_block import BreakInside
+
+__all__ = ("NBPRINT_BLOCK_MIME", "NBPrintBlock")
+
+NBPRINT_BLOCK_MIME = "application/nbprint.block+json"
+
+# Fully qualified target path used by ingestion to construct the right
+# Content subclass. Kept here to avoid an import-time circular.
+_PAGE_BLOCK_TYPE = "nbprint.ContentPageBlock"
+
+
+class NBPrintBlock:
+    """Runtime helper that marks the current cell as a ``ContentPageBlock``.
+
+    Parameters
+    ----------
+    section : str | None
+        Target document section (e.g. ``"middlematter"``). Routed
+        through the same mechanism as :class:`NBPrintCell`.
+    span : int | None
+        Number of columns to span in a parent grid/columns layout.
+    rows : int | None
+        Number of rows to span in a grid layout.
+    area : str | None
+        Named grid area (paired with ``ContentPageBox.grid_template``).
+    aspect : float | str | None
+        Aspect-ratio constraint. Accepts ``1.7777``, ``"16:9"``, or a
+        raw CSS value like ``"16/9"``.
+    min_height, max_height : str | None
+        CSS sizing constraints (e.g. ``"4in"``).
+    break_inside : {"avoid", "auto"}
+        ``"avoid"`` (default): keep the block on one page.
+        ``"auto"``: allow it to flow across pages.
+    scalable : bool | None
+        Hint for the page-box ``fit`` pass: ``True`` to mark this
+        block's content as scalable, ``False`` to opt out, ``None``
+        (default) to auto-detect at render from child MIME types.
+    css : str | None
+        Extra CSS to merge into the block.
+    style : Style | None
+        Structured ``Style`` object merged into the block's style.
+    classname : str | list[str] | None
+        Extra CSS class(es) for the block wrapper.
+    attrs : dict[str, str] | None
+        Extra HTML attributes for the block wrapper.
+    ignore : bool | None
+        If ``True``, hide the block from the final output.
+    emit : bool
+        If ``True`` (default) immediately publish the metadata via
+        ``display()``. Set to ``False`` when you only want to use the
+        object as a context manager; metadata is emitted on
+        ``__enter__``.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        section: str | None = None,
+        span: int | None = None,
+        rows: int | None = None,
+        area: str | None = None,
+        aspect: float | str | None = None,
+        min_height: str | None = None,
+        max_height: str | None = None,
+        break_inside: BreakInside = "avoid",
+        scalable: bool | None = None,
+        css: str | None = None,
+        style: Style | None = None,
+        classname: str | list[str] | None = None,
+        attrs: dict[str, str] | None = None,
+        ignore: bool | None = None,
+        emit: bool = True,
+    ) -> None:
+        self.section = section
+        self.span = span
+        self.rows = rows
+        self.area = area
+        self.aspect = aspect
+        self.min_height = min_height
+        self.max_height = max_height
+        self.break_inside = break_inside
+        self.scalable = scalable
+        self.css = css
+        self.style = style
+        self.classname = classname
+        self.attrs = attrs
+        self.ignore = ignore
+        self._emitted = False
+
+        if emit:
+            self._emit()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serializable dict of fields to merge into the cell model.
+
+        Always includes ``type_`` so the ingestion path constructs a
+        :class:`ContentPageBlock` rather than a plain :class:`Content`.
+        """
+        d: dict[str, Any] = {
+            "type_": _PAGE_BLOCK_TYPE,
+            "break_inside": self.break_inside,
+        }
+        if self.section is not None:
+            d["section"] = self.section
+        if self.span is not None:
+            d["span"] = self.span
+        if self.rows is not None:
+            d["rows"] = self.rows
+        if self.area is not None:
+            d["area"] = self.area
+        if self.aspect is not None:
+            d["aspect"] = self.aspect
+        if self.min_height is not None:
+            d["min_height"] = self.min_height
+        if self.max_height is not None:
+            d["max_height"] = self.max_height
+        if self.scalable is not None:
+            d["scalable"] = self.scalable
+        if self.css is not None:
+            d["css"] = self.css
+        if self.style is not None:
+            d["style"] = self.style.model_dump(mode="json", exclude_none=True)
+        if self.classname is not None:
+            d["classname"] = self.classname
+        if self.attrs is not None:
+            d["attrs"] = self.attrs
+        if self.ignore is not None:
+            d["ignore"] = self.ignore
+        return d
+
+    def _emit(self) -> None:
+        if self._emitted:
+            return
+        data = {NBPRINT_BLOCK_MIME: json.dumps(self.to_dict())}
+        display(data, raw=True)
+        self._emitted = True
+
+    def __enter__(self) -> Self:
+        if not self._emitted:
+            self._emit()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        return None

--- a/nbprint/config/content/_layout_presets.py
+++ b/nbprint/config/content/_layout_presets.py
@@ -1,0 +1,233 @@
+"""Shared layout-preset CSS used by :class:`ContentPageBox` and the
+flex/inline layout containers.
+
+Single source of truth so a tweak to the bare ``display: flex`` rule
+(for example) flows to every container that uses it. The page-box
+preset CSS in 9.4 reuses these constants verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Literal
+
+__all__ = (
+    "FLEX_COLUMN_CSS",
+    "FLEX_ROW_CSS",
+    "INLINE_CSS",
+    "PAGE_BOX_BASE_CSS",
+    "PAGE_BOX_PRESET_BUILDERS",
+    "PageBoxLayout",
+    "build_page_box_css",
+)
+
+
+# A preset builder takes optional gap/padding/align/justify and returns
+# a CSS fragment to append after :scope { ... base ... }.
+_Builder = Callable[..., str]
+
+
+PageBoxLayout = Literal[
+    "flow",
+    "columns-2",
+    "columns-3",
+    "grid-2x2",
+    "grid-3x2",
+    "grid-3x3",
+    "grid",
+    "flex-row",
+    "flex-column",
+    "inline",
+    "masonry",
+    "custom",
+]
+
+
+# ── Bare display rules used by the flex/inline layout containers and
+# reused by the page-box presets below. Keeping them here means a
+# change to "display: flex" propagates to every consumer. ────────────
+FLEX_ROW_CSS = "display: flex; flex-direction: row; break-inside: auto;"
+FLEX_COLUMN_CSS = "display: flex; flex-direction: column; break-inside: auto;"
+INLINE_CSS = "display: block;"
+
+
+# Base page-box CSS: at-least-one-page guarantee, hard breaks, and a
+# vertical fill so empty pages still render. Preset CSS is appended
+# after this base; user-supplied ``css`` (when not the default)
+# fully replaces both.
+PAGE_BOX_BASE_CSS = (
+    ":scope {\n"
+    "  break-before: page;\n"
+    "  break-after: page;\n"
+    "  break-inside: auto;\n"
+    "  display: block;\n"
+    "  min-height: var(--pagedjs-pagebox-min-height, 100%);\n"
+    "}\n"
+)
+
+
+def _join_rules(rules: list[str]) -> str:
+    return " ".join(rule for rule in rules if rule)
+
+
+def _scope_block(rules: list[str]) -> str:
+    body = _join_rules(rules)
+    return f":scope {{ {body} }}\n" if body else ""
+
+
+def _columns_builder(count: int) -> _Builder:
+    def build(*, gap: str | None, padding: str | None, **_) -> str:
+        rules = [f"column-count: {count};", "column-fill: balance;"]
+        if gap is not None:
+            rules.append(f"column-gap: {gap};")
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        return _scope_block(rules)
+
+    return build
+
+
+def _grid_builder(template: str | None) -> _Builder:
+    def build(*, gap: str | None, padding: str | None, align: str | None, justify: str | None) -> str:
+        rules = ["display: grid;", "grid-auto-flow: row dense;"]
+        if template is not None:
+            rules.append(f"grid-template-columns: {template};")
+        if gap is not None:
+            rules.append(f"gap: {gap};")
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        if align is not None:
+            rules.append(f"align-items: {align};")
+        if justify is not None:
+            rules.append(f"justify-items: {justify};")
+        return _scope_block(rules)
+
+    return build
+
+
+def _grid_areas_builder() -> _Builder:
+    """Bare ``display: grid`` for named-area / custom grid templates.
+
+    The actual ``grid-template`` value is supplied separately by the
+    page-box (Phase 9.5 will set ``grid_template`` on the box).
+    """
+
+    def build(*, gap: str | None, padding: str | None, align: str | None, justify: str | None) -> str:
+        rules = ["display: grid;", "grid-auto-flow: row dense;"]
+        if gap is not None:
+            rules.append(f"gap: {gap};")
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        if align is not None:
+            rules.append(f"align-items: {align};")
+        if justify is not None:
+            rules.append(f"justify-items: {justify};")
+        return _scope_block(rules)
+
+    return build
+
+
+def _flex_builder(direction_css: str) -> _Builder:
+    def build(*, gap: str | None, padding: str | None, align: str | None, justify: str | None) -> str:
+        rules = [direction_css]
+        if gap is not None:
+            rules.append(f"gap: {gap};")
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        if align is not None:
+            rules.append(f"align-items: {align};")
+        if justify is not None:
+            rules.append(f"justify-content: {justify};")
+        return _scope_block(rules)
+
+    return build
+
+
+def _inline_builder() -> _Builder:
+    def build(*, gap: str | None, padding: str | None, **_) -> str:
+        rules = [INLINE_CSS]
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        scope = _scope_block(rules)
+        if gap is not None:
+            # column-gap doesn't apply to inline-block layouts; emit a
+            # margin-left on adjacent siblings as the closest equivalent.
+            scope += f":scope > * + * {{ margin-left: {gap}; }}\n"
+        return scope
+
+    return build
+
+
+def _masonry_builder() -> _Builder:
+    def build(*, gap: str | None, padding: str | None, **_) -> str:
+        # Native CSS masonry where supported; the JS polyfill in
+        # measure.js (Phase 9.17) handles browsers without support.
+        rules = [
+            "display: grid;",
+            "grid-template-rows: masonry;",
+            "grid-auto-flow: row;",
+        ]
+        if gap is not None:
+            rules.append(f"gap: {gap};")
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        return _scope_block(rules)
+
+    return build
+
+
+def _flow_builder() -> _Builder:
+    def build(*, gap: str | None, padding: str | None, **_) -> str:
+        rules = []
+        if padding is not None:
+            rules.append(f"padding: {padding};")
+        scope = _scope_block(rules)
+        if gap is not None:
+            # In flow mode, "gap" is a margin between consecutive
+            # block children — the closest equivalent in normal flow.
+            scope += f":scope > * + * {{ margin-top: {gap}; }}\n"
+        return scope
+
+    return build
+
+
+# Preset name → builder callable. Builders take ``gap``, ``padding``,
+# ``align``, ``justify`` keyword args (any may be ``None``) and return
+# a string of CSS rules to be appended to ``:scope { ... }``.
+PAGE_BOX_PRESET_BUILDERS = {
+    "flow": _flow_builder(),
+    "columns-2": _columns_builder(2),
+    "columns-3": _columns_builder(3),
+    "grid-2x2": _grid_builder("repeat(2, 1fr)"),
+    "grid-3x2": _grid_builder("repeat(3, 1fr)"),
+    "grid-3x3": _grid_builder("repeat(3, 1fr)"),
+    "grid": _grid_areas_builder(),
+    "flex-row": _flex_builder(FLEX_ROW_CSS),
+    "flex-column": _flex_builder(FLEX_COLUMN_CSS),
+    "inline": _inline_builder(),
+    "masonry": _masonry_builder(),
+    # ``custom`` deliberately omitted — caller handles it (no preset
+    # CSS appended; user owns ``:scope``).
+}
+
+
+def build_page_box_css(
+    layout: PageBoxLayout,
+    *,
+    gap: str | None,
+    padding: str | None,
+    align: str | None,
+    justify: str | None,
+) -> str:
+    """Build the CSS for a :class:`ContentPageBox` with the given layout.
+
+    For ``layout="custom"`` returns only the base CSS — the user owns
+    ``:scope`` styling. For the ``flow`` preset, returns the base plus
+    any margin/padding rules. For all other presets, returns the base
+    plus a second ``:scope { ... }`` block carrying the preset rules.
+    """
+    if layout == "custom":
+        return PAGE_BOX_BASE_CSS
+
+    builder = PAGE_BOX_PRESET_BUILDERS[layout]
+    preset_css = builder(gap=gap, padding=padding, align=align, justify=justify)
+    return PAGE_BOX_BASE_CSS + preset_css

--- a/nbprint/config/content/page.py
+++ b/nbprint/config/content/page.py
@@ -3,6 +3,7 @@ from pydantic import Field
 
 from nbprint.config.base import Role
 
+from ._layout_presets import FLEX_COLUMN_CSS, FLEX_ROW_CSS, INLINE_CSS
 from .base import Content
 
 __all__ = (
@@ -64,7 +65,7 @@ class ContentInlineLayout(Content):
     # override role
     role: Role = Role.LAYOUT
 
-    css: str = ":scope { display: block; }"
+    css: str = f":scope {{ {INLINE_CSS} }}"
     esm: str = """
 function render(meta, elem) {
     let data = JSON.parse(meta.data);
@@ -91,12 +92,8 @@ function render(meta, elem) {
 
 
 class ContentFlexColumnLayout(_ContentFlexLayout):
-    css: str = """
-:scope { display: flex; flex-direction: column; break-inside: auto; }
-"""
+    css: str = f":scope {{ {FLEX_COLUMN_CSS} }}\n"
 
 
 class ContentFlexRowLayout(_ContentFlexLayout):
-    css: str = """
-:scope { display: flex; flex-direction: row; break-inside: auto; }
-"""
+    css: str = f":scope {{ {FLEX_ROW_CSS} }}\n"

--- a/nbprint/config/content/page_box.py
+++ b/nbprint/config/content/page_box.py
@@ -32,9 +32,11 @@ from pydantic import Field, model_validator
 
 from nbprint.config.common import PageOrientation, PageSize
 
+from ._layout_presets import PAGE_BOX_BASE_CSS, PageBoxLayout, build_page_box_css
 from .base import Content
+from .page_block import ContentPageBlock
 
-__all__ = ("ContentPageBox", "PageBoxFit")
+__all__ = ("ContentPageBox", "PageBoxFit", "PageBoxLayout")
 
 
 PageBoxFit = Literal["scale", "shrink", "strict", "none"]
@@ -44,15 +46,7 @@ PageBoxFit = Literal["scale", "shrink", "strict", "none"]
 # so empty or near-empty boxes still render a full page (at-least-one-page
 # guarantee), and allow children to break inside when overflowing to the
 # next page.
-_DEFAULT_PAGE_BOX_CSS = (
-    ":scope {\n"
-    "  break-before: page;\n"
-    "  break-after: page;\n"
-    "  break-inside: auto;\n"
-    "  display: block;\n"
-    "  min-height: var(--pagedjs-pagebox-min-height, 100%);\n"
-    "}\n"
-)
+_DEFAULT_PAGE_BOX_CSS = PAGE_BOX_BASE_CSS
 
 
 class ContentPageBox(Content):
@@ -97,6 +91,40 @@ class ContentPageBox(Content):
         description="Minimum number of pages this box must produce. Guaranteed even when the box is empty.",
     )
 
+    # ── Layout preset ────────────────────────────────────────────────
+    # Each preset emits the corresponding CSS on ``:scope``; the
+    # ``custom`` preset suppresses preset CSS so the user owns
+    # ``:scope`` styling via the inherited ``css`` field.
+    layout: PageBoxLayout = Field(
+        default="flow",
+        description=(
+            "Built-in layout for child blocks. 'flow' (default): "
+            "native block-flow. 'columns-2'/'columns-3': CSS multi-column. "
+            "'grid-2x2'/'grid-3x2'/'grid-3x3': fixed grids. 'grid': bare "
+            "`display: grid` — pair with `grid_template` (Phase 9.5) for "
+            "named areas. 'flex-row'/'flex-column'/'inline': reuse the "
+            "existing flex/inline layout containers' CSS. 'masonry': "
+            "native CSS masonry with a JS polyfill (Phase 9.17). "
+            "'custom': suppress preset CSS — the user owns `:scope`."
+        ),
+    )
+    gap: str | None = Field(
+        default=None,
+        description="CSS `gap` (or `column-gap` for the columns presets) between children.",
+    )
+    padding: str | None = Field(
+        default=None,
+        description="CSS `padding` applied to the page-box `:scope`.",
+    )
+    align: str | None = Field(
+        default=None,
+        description="CSS `align-items` for grid/flex presets (no-op for `flow`/`columns-*`/`custom`).",
+    )
+    justify: str | None = Field(
+        default=None,
+        description=("CSS `justify-items` (grid presets) or `justify-content` (flex presets). No-op for `flow`/`columns-*`/`custom`."),
+    )
+
     # Inherit ``content: str | list[Content] | None`` from ``Content``.
     # Runtime (NBPrintPage single-cell) use sets it to the cell source;
     # YAML use sets it to a list of child ``Content`` models.
@@ -105,7 +133,10 @@ class ContentPageBox(Content):
 
     @model_validator(mode="after")
     def _populate_data_attrs(self) -> ContentPageBox:
-        """Seed ``attrs`` and ``tags`` with page-box defaults.
+        """Seed ``attrs`` and ``tags`` with page-box defaults, build the
+        preset CSS, and auto-wrap bare child :class:`Content` into
+        :class:`ContentPageBlock` so the DOM shape is always
+        ``page-box > block > <user content>``.
 
         Values already present in ``attrs`` win (so CLI overrides of
         ``attrs.data-nbprint-*`` take precedence). Mutates in place to
@@ -118,8 +149,46 @@ class ContentPageBox(Content):
         attrs = self.attrs  # type: ignore[assignment]
         attrs.setdefault("data-nbprint-page-box", self._id)
         attrs["data-nbprint-fit"] = str(self.fit)
+        attrs["data-nbprint-layout"] = self.layout
         if self.min_pages > 1:
             attrs.setdefault("data-nbprint-min-pages", str(self.min_pages))
+
+        # Build preset CSS unless the user has supplied a non-default
+        # ``css`` value (which fully overrides — opt-out for power
+        # users). When ``layout='custom'`` the base CSS is preserved
+        # but no preset rules are appended, so the user's ``:scope``
+        # additions win cleanly.
+        if self.css in {_DEFAULT_PAGE_BOX_CSS, PAGE_BOX_BASE_CSS}:
+            object.__setattr__(
+                self,
+                "css",
+                build_page_box_css(
+                    self.layout,
+                    gap=self.gap,
+                    padding=self.padding,
+                    align=self.align,
+                    justify=self.justify,
+                ),
+            )
+
+        # Auto-wrap any bare child Content into a ContentPageBlock so
+        # downstream layout passes can rely on a uniform DOM shape.
+        # Strings (single-cell runtime use) and existing blocks pass
+        # through unchanged.
+        if isinstance(self.content, list):
+            wrapped: list = []
+            for child in self.content:
+                if isinstance(child, ContentPageBlock):
+                    wrapped.append(child)
+                elif isinstance(child, Content):
+                    wrapped.append(ContentPageBlock(content=[child]))
+                else:
+                    # Non-Content payload (shouldn't happen via normal
+                    # construction); pass through to surface the issue
+                    # downstream rather than silently mangle it.
+                    wrapped.append(child)
+            object.__setattr__(self, "content", wrapped)
+
         return self
 
     def __call__(self, **_) -> HTML:

--- a/nbprint/config/content/page_box.py
+++ b/nbprint/config/content/page_box.py
@@ -42,6 +42,31 @@ __all__ = ("ContentPageBox", "PageBoxFit", "PageBoxLayout")
 PageBoxFit = Literal["scale", "shrink", "strict", "none"]
 
 
+def _extract_grid_template_areas(template: str) -> set[str]:
+    """Pull the set of area names from a CSS ``grid-template`` value.
+
+    The ``grid-template`` shorthand interleaves quoted row strings (the
+    area names) with track sizes and a ``/`` separator. Non-area tokens
+    (``.`` placeholders, sizes, fractions, the ``/`` itself) are
+    discarded. Empty quotes parse to no areas, which is fine.
+
+    Robust to:
+      * single or double quotes
+      * multi-row templates (``"a a" "b c"``)
+      * track sizes interleaved (``"a a" 1fr "b c" 2fr / 1fr 1fr``)
+      * the ``.`` placeholder (denotes an empty cell)
+    """
+    import re
+
+    quoted = re.findall(r"['\"]([^'\"]*)['\"]", template)
+    areas: set[str] = set()
+    for row in quoted:
+        for token in row.split():
+            if token and token != ".":  # noqa: S105 - "token" here is a CSS grid area name, not a credential
+                areas.add(token)
+    return areas
+
+
 # Default CSS: force page breaks around the box, fill the page vertically
 # so empty or near-empty boxes still render a full page (at-least-one-page
 # guarantee), and allow children to break inside when overflowing to the
@@ -124,6 +149,15 @@ class ContentPageBox(Content):
         default=None,
         description=("CSS `justify-items` (grid presets) or `justify-content` (flex presets). No-op for `flow`/`columns-*`/`custom`."),
     )
+    grid_template: str | None = Field(
+        default=None,
+        description=(
+            "Raw CSS `grid-template` value (e.g. `\"'hero hero' 'chart table' / 1fr 1fr\"`). "
+            "Only meaningful when `layout='grid'`. Validator cross-checks "
+            "that every `ContentPageBlock.area` referenced by children "
+            "appears in the template; unused areas are allowed."
+        ),
+    )
 
     # Inherit ``content: str | list[Content] | None`` from ``Content``.
     # Runtime (NBPrintPage single-cell) use sets it to the cell source;
@@ -159,17 +193,40 @@ class ContentPageBox(Content):
         # but no preset rules are appended, so the user's ``:scope``
         # additions win cleanly.
         if self.css in {_DEFAULT_PAGE_BOX_CSS, PAGE_BOX_BASE_CSS}:
-            object.__setattr__(
-                self,
-                "css",
-                build_page_box_css(
-                    self.layout,
-                    gap=self.gap,
-                    padding=self.padding,
-                    align=self.align,
-                    justify=self.justify,
-                ),
+            preset_css = build_page_box_css(
+                self.layout,
+                gap=self.gap,
+                padding=self.padding,
+                align=self.align,
+                justify=self.justify,
             )
+            # When ``grid_template`` is set, append a ``grid-template``
+            # declaration. We don't gate on ``layout='grid'`` because
+            # ``grid-template`` is harmless for non-grid layouts (the
+            # browser ignores it) and gating would surprise users who
+            # try ``layout='grid-2x2'`` + ``grid_template``.
+            if self.grid_template is not None:
+                preset_css += f":scope {{ grid-template: {self.grid_template}; }}\n"
+            object.__setattr__(self, "css", preset_css)
+
+        # Cross-check: every referenced area in child blocks must
+        # appear in ``grid_template``. Unused template areas are
+        # allowed (empty cells). Skipped when ``grid_template`` is
+        # ``None`` (no constraint) or when the user supplied a custom
+        # ``css`` (we don't know what areas it defines).
+        if self.grid_template is not None and isinstance(self.content, list):
+            template_areas = _extract_grid_template_areas(self.grid_template)
+            for child in self.content:
+                if not isinstance(child, ContentPageBlock):
+                    continue
+                if child.area is not None and child.area not in template_areas:
+                    msg = (
+                        f"ContentPageBox.grid_template does not define "
+                        f"area '{child.area}' referenced by child block "
+                        f"'{child._id}'. Defined areas: "
+                        f"{sorted(template_areas) or '<none>'}"
+                    )
+                    raise ValueError(msg)
 
         # Auto-wrap any bare child Content into a ContentPageBlock so
         # downstream layout passes can rely on a uniform DOM shape.

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 
 from nbprint import __version__
 from nbprint.config.base import BaseModel, Role, _append_or_extend
+from nbprint.config.block_runtime import NBPRINT_BLOCK_MIME
 from nbprint.config.cell import NBPRINT_MIME
 from nbprint.config.common import Style
 from nbprint.config.content import Content, ContentCode, ContentMarkdown
@@ -260,8 +261,9 @@ class Configuration(CallableModel, BaseModel):
 
         Looks for outputs containing any of the nbprint runtime MIME
         types (``application/nbprint.cell+json``,
-        ``application/nbprint.page+json``) and returns the parsed
-        metadata dict, or ``None``. Both MIME types use the same merge
+        ``application/nbprint.page+json``,
+        ``application/nbprint.block+json``) and returns the parsed
+        metadata dict, or ``None``. All MIME types use the same merge
         semantics into the cell's nbprint metadata; the kind of model
         constructed is later driven by the embedded ``type_`` field.
         """
@@ -270,7 +272,7 @@ class Configuration(CallableModel, BaseModel):
         outputs = cell.get("outputs", [])
         for output in outputs:
             data = output.get("data", {})
-            for mime in (NBPRINT_MIME, NBPRINT_PAGE_MIME):
+            for mime in (NBPRINT_MIME, NBPRINT_PAGE_MIME, NBPRINT_BLOCK_MIME):
                 if mime in data:
                     raw = data[mime]
                     if isinstance(raw, str):

--- a/nbprint/config/page_runtime.py
+++ b/nbprint/config/page_runtime.py
@@ -95,6 +95,7 @@ class NBPrintPage:
         padding: str | None = None,
         align: str | None = None,
         justify: str | None = None,
+        grid_template: str | None = None,
         css: str | None = None,
         style: Style | None = None,
         classname: str | list[str] | None = None,
@@ -113,6 +114,7 @@ class NBPrintPage:
         self.padding = padding
         self.align = align
         self.justify = justify
+        self.grid_template = grid_template
         self.css = css
         self.style = style
         self.classname = classname
@@ -151,6 +153,8 @@ class NBPrintPage:
             d["align"] = self.align
         if self.justify is not None:
             d["justify"] = self.justify
+        if self.grid_template is not None:
+            d["grid_template"] = self.grid_template
         if self.css is not None:
             d["css"] = self.css
         if self.style is not None:

--- a/nbprint/config/page_runtime.py
+++ b/nbprint/config/page_runtime.py
@@ -35,7 +35,7 @@ from IPython.display import display
 from typing_extensions import Self
 
 from nbprint.config.common import PageOrientation, PageSize, Style
-from nbprint.config.content.page_box import PageBoxFit
+from nbprint.config.content.page_box import PageBoxFit, PageBoxLayout
 
 __all__ = ("NBPRINT_PAGE_MIME", "NBPrintPage")
 
@@ -90,6 +90,11 @@ class NBPrintPage:
         page_orientation: PageOrientation | str | None = None,
         page_margins: str | None = None,
         min_pages: int = 1,
+        layout: PageBoxLayout = "flow",
+        gap: str | None = None,
+        padding: str | None = None,
+        align: str | None = None,
+        justify: str | None = None,
         css: str | None = None,
         style: Style | None = None,
         classname: str | list[str] | None = None,
@@ -103,6 +108,11 @@ class NBPrintPage:
         self.page_orientation = page_orientation
         self.page_margins = page_margins
         self.min_pages = min_pages
+        self.layout = layout
+        self.gap = gap
+        self.padding = padding
+        self.align = align
+        self.justify = justify
         self.css = css
         self.style = style
         self.classname = classname
@@ -123,6 +133,7 @@ class NBPrintPage:
             "type_": _PAGE_BOX_TYPE,
             "fit": self.fit,
             "min_pages": self.min_pages,
+            "layout": self.layout,
         }
         if self.section is not None:
             d["section"] = self.section
@@ -132,6 +143,14 @@ class NBPrintPage:
             d["page_orientation"] = str(self.page_orientation)
         if self.page_margins is not None:
             d["page_margins"] = self.page_margins
+        if self.gap is not None:
+            d["gap"] = self.gap
+        if self.padding is not None:
+            d["padding"] = self.padding
+        if self.align is not None:
+            d["align"] = self.align
+        if self.justify is not None:
+            d["justify"] = self.justify
         if self.css is not None:
             d["css"] = self.css
         if self.style is not None:

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -1586,3 +1586,265 @@ class TestPageBoxLayout:
         assert d["layout"] == "grid-2x2"
         assert d["gap"] == "1rem"
         assert d["padding"] == "0.5in"
+
+
+class TestPageBoxGridTemplate:
+    """Phase 9.5 — named-area grids on ContentPageBox."""
+
+    def test_grid_template_emitted_in_css(self):
+        from nbprint.config.content import ContentPageBox
+
+        tmpl = "'hero hero' 'chart table' / 1fr 1fr"
+        box = ContentPageBox(layout="grid", grid_template=tmpl)
+        assert f"grid-template: {tmpl}" in box.css
+
+    def test_grid_template_default_none(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="grid")
+        assert box.grid_template is None
+        assert "grid-template:" not in box.css
+
+    def test_grid_template_validator_accepts_referenced_areas(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        ContentPageBox(
+            layout="grid",
+            grid_template="'hero hero' 'chart table' / 1fr 1fr",
+            content=[
+                ContentPageBlock(area="hero", content=[ContentMarkdown(content="h")]),
+                ContentPageBlock(area="chart", content=[ContentMarkdown(content="c")]),
+                ContentPageBlock(area="table", content=[ContentMarkdown(content="t")]),
+            ],
+        )
+        # No exception → success.
+
+    def test_grid_template_validator_allows_unused_areas(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        ContentPageBox(
+            layout="grid",
+            grid_template="'hero hero' 'a b' 'c d' / 1fr 1fr",
+            content=[
+                ContentPageBlock(area="hero", content=[ContentMarkdown(content="h")]),
+                # 'a', 'b', 'c', 'd' all unreferenced — allowed.
+            ],
+        )
+
+    def test_grid_template_validator_rejects_undefined_area(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        with pytest.raises(ValidationError, match="does not define area 'sidebar'"):
+            ContentPageBox(
+                layout="grid",
+                grid_template="'hero hero' 'chart table' / 1fr 1fr",
+                content=[
+                    ContentPageBlock(area="sidebar", content=[ContentMarkdown(content="x")]),
+                ],
+            )
+
+    def test_grid_template_extracts_areas_with_dot_placeholder(self):
+        """``.`` is the empty-cell placeholder — must not be treated as an area name."""
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        # No exception even though template uses '.'; child only references 'a'.
+        ContentPageBox(
+            layout="grid",
+            grid_template="'a a' '. b' / 1fr 1fr",
+            content=[
+                ContentPageBlock(area="a", content=[ContentMarkdown(content="x")]),
+            ],
+        )
+
+    def test_grid_template_with_track_sizes_interleaved(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        ContentPageBox(
+            layout="grid",
+            grid_template='"a a" 1fr "b c" 2fr / 1fr 1fr',
+            content=[
+                ContentPageBlock(area="a", content=[ContentMarkdown(content="x")]),
+                ContentPageBlock(area="b", content=[ContentMarkdown(content="y")]),
+                ContentPageBlock(area="c", content=[ContentMarkdown(content="z")]),
+            ],
+        )
+
+    def test_extract_grid_template_areas_helper(self):
+        from nbprint.config.content.page_box import _extract_grid_template_areas
+
+        assert _extract_grid_template_areas("'a b' 'c d' / 1fr 1fr") == {"a", "b", "c", "d"}
+        assert _extract_grid_template_areas("'a a' '. b'") == {"a", "b"}
+        assert _extract_grid_template_areas('"hero hero" "chart table"') == {"hero", "chart", "table"}
+        assert _extract_grid_template_areas("") == set()
+
+
+class TestNBPrintBlock:
+    """Phase 9.6 — NBPrintBlock runtime API."""
+
+    def test_top_level_export(self):
+        import nbprint
+
+        assert hasattr(nbprint, "NBPrintBlock")
+        assert hasattr(nbprint, "NBPRINT_BLOCK_MIME")
+
+    def test_to_dict_emits_type(self):
+        from nbprint import NBPrintBlock
+
+        block = NBPrintBlock(emit=False)
+        d = block.to_dict()
+        assert d["type_"] == "nbprint.ContentPageBlock"
+        assert d["break_inside"] == "avoid"
+
+    def test_to_dict_omits_none_fields(self):
+        from nbprint import NBPrintBlock
+
+        d = NBPrintBlock(emit=False).to_dict()
+        # Only type_ and break_inside present at minimum.
+        for key in (
+            "section",
+            "span",
+            "rows",
+            "area",
+            "aspect",
+            "min_height",
+            "max_height",
+            "scalable",
+            "css",
+            "style",
+            "classname",
+            "attrs",
+            "ignore",
+        ):
+            assert key not in d
+
+    def test_to_dict_includes_all_overrides(self):
+        from nbprint import NBPrintBlock
+
+        block = NBPrintBlock(
+            emit=False,
+            section="middlematter",
+            span=2,
+            rows=1,
+            area="hero",
+            aspect="16:9",
+            min_height="2in",
+            max_height="6in",
+            break_inside="auto",
+            scalable=True,
+            css=":scope { background: blue; }",
+            classname="hero-block",
+            attrs={"data-test": "1"},
+            ignore=False,
+        )
+        d = block.to_dict()
+        assert d["section"] == "middlematter"
+        assert d["span"] == 2
+        assert d["rows"] == 1
+        assert d["area"] == "hero"
+        assert d["aspect"] == "16:9"
+        assert d["min_height"] == "2in"
+        assert d["max_height"] == "6in"
+        assert d["break_inside"] == "auto"
+        assert d["scalable"] is True
+        assert d["css"] == ":scope { background: blue; }"
+        assert d["classname"] == "hero-block"
+        assert d["attrs"] == {"data-test": "1"}
+        assert d["ignore"] is False
+
+    def test_emit_publishes_mime(self):
+        from unittest.mock import patch
+
+        from nbprint import NBPRINT_BLOCK_MIME, NBPrintBlock
+
+        with patch("nbprint.config.block_runtime.display") as mock_display:
+            NBPrintBlock(span=2)
+            assert mock_display.call_count == 1
+            args, kwargs = mock_display.call_args
+            data = args[0]
+            assert NBPRINT_BLOCK_MIME in data
+            assert kwargs == {"raw": True}
+
+    def test_context_manager_emits_once(self):
+        from unittest.mock import patch
+
+        from nbprint import NBPrintBlock
+
+        with patch("nbprint.config.block_runtime.display") as mock_display:
+            block = NBPrintBlock(emit=False)
+            assert mock_display.call_count == 0
+            with block:
+                pass
+            assert mock_display.call_count == 1
+            with block:
+                pass
+            assert mock_display.call_count == 1
+
+    def test_ingestion_produces_page_block(self):
+        """Runtime MIME output builds a ContentPageBlock in Configuration ingestion."""
+        import json
+
+        from nbformat.v4 import new_code_cell, new_notebook
+
+        from nbprint import NBPRINT_BLOCK_MIME
+        from nbprint.config.content import ContentPageBlock
+        from nbprint.config.core.config import Configuration
+
+        nb = new_notebook()
+        cell = new_code_cell(source="display(chart)", metadata={"tags": []})
+        payload = {
+            "type_": "nbprint.ContentPageBlock",
+            "span": 2,
+            "aspect": "16:9",
+            "break_inside": "avoid",
+        }
+        cell.outputs = [
+            {
+                "output_type": "display_data",
+                "data": {NBPRINT_BLOCK_MIME: json.dumps(payload)},
+                "metadata": {},
+            }
+        ]
+        nb.cells = [cell]
+
+        values = {"content": ContentMarshall()}
+        Configuration._process_cells(values, nb)
+
+        assert len(values["content"].middlematter) == 1
+        block = values["content"].middlematter[0]
+        assert isinstance(block, ContentPageBlock)
+        assert block.span == 2
+        assert block.aspect == "16:9"
+        # Source preserved as the block's content.
+        assert block.content == "display(chart)"
+
+    def test_nbprint_page_runtime_passes_grid_template(self):
+        """Phase 9.5 + runtime: NBPrintPage carries grid_template through."""
+        from nbprint import NBPrintPage
+
+        tmpl = "'a a' 'b c' / 1fr 1fr"
+        page = NBPrintPage(emit=False, layout="grid", grid_template=tmpl)
+        d = page.to_dict()
+        assert d["grid_template"] == tmpl

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -1404,3 +1404,185 @@ class TestContentPageBlock:
         block = ContentPageBlock(content=[ContentMarkdown(content="# hi")])
         assert isinstance(block.content, list)
         assert len(block.content) == 1
+
+
+class TestPageBoxLayout:
+    """Phase 9.4 — layout presets on ContentPageBox + auto-wrap."""
+
+    def test_layout_default_is_flow(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox()
+        assert box.layout == "flow"
+        assert box.attrs["data-nbprint-layout"] == "flow"
+
+    def test_columns_2_emits_column_count(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="columns-2")
+        assert "column-count: 2" in box.css
+        assert box.attrs["data-nbprint-layout"] == "columns-2"
+
+    def test_columns_3_emits_column_count(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="columns-3", gap="0.5in")
+        assert "column-count: 3" in box.css
+        assert "column-gap: 0.5in" in box.css
+
+    def test_grid_2x2_emits_grid_template(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="grid-2x2")
+        assert "display: grid" in box.css
+        assert "grid-template-columns: repeat(2, 1fr)" in box.css
+
+    def test_grid_3x2_emits_grid_template(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="grid-3x2", gap="1rem", align="center", justify="stretch")
+        assert "grid-template-columns: repeat(3, 1fr)" in box.css
+        assert "gap: 1rem" in box.css
+        assert "align-items: center" in box.css
+        assert "justify-items: stretch" in box.css
+
+    def test_grid_bare_no_template_columns(self):
+        """layout='grid' is the named-area form — emits display: grid but no fixed columns."""
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="grid")
+        assert "display: grid" in box.css
+        assert "grid-template-columns" not in box.css
+
+    def test_flex_row_reuses_shared_css(self):
+        from nbprint.config.content import ContentFlexRowLayout, ContentPageBox
+
+        box = ContentPageBox(layout="flex-row")
+        assert "display: flex" in box.css
+        assert "flex-direction: row" in box.css
+        # Shared constant — verify the existing layout container
+        # carries the same direction CSS.
+        assert "flex-direction: row" in ContentFlexRowLayout().css
+
+    def test_flex_column_reuses_shared_css(self):
+        from nbprint.config.content import ContentFlexColumnLayout, ContentPageBox
+
+        box = ContentPageBox(layout="flex-column", gap="1rem", justify="space-between")
+        assert "flex-direction: column" in box.css
+        assert "gap: 1rem" in box.css
+        assert "justify-content: space-between" in box.css
+        assert "flex-direction: column" in ContentFlexColumnLayout().css
+
+    def test_inline_preset(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="inline", gap="1rem")
+        assert "display: block" in box.css
+        # Inline gap maps to margin-left on adjacent siblings.
+        assert "margin-left: 1rem" in box.css
+
+    def test_masonry_preset(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="masonry", gap="0.25in")
+        assert "display: grid" in box.css
+        assert "grid-template-rows: masonry" in box.css
+        assert "gap: 0.25in" in box.css
+
+    def test_flow_preset_with_gap_emits_margin(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="flow", gap="1rem")
+        assert "margin-top: 1rem" in box.css
+
+    def test_custom_layout_preserves_base_only(self):
+        """layout='custom' suppresses preset CSS so the user owns :scope."""
+        from nbprint.config.content import ContentPageBox
+        from nbprint.config.content._layout_presets import PAGE_BOX_BASE_CSS
+
+        box = ContentPageBox(layout="custom")
+        assert box.css == PAGE_BOX_BASE_CSS
+        # Preset-only rules are absent.
+        assert "column-count" not in box.css
+        assert "display: grid" not in box.css
+
+    def test_user_css_override_wins(self):
+        """When the user supplies non-default css, preset CSS is not emitted."""
+        from nbprint.config.content import ContentPageBox
+
+        custom = ":scope { background: red; }\n"
+        box = ContentPageBox(layout="columns-2", css=custom)
+        assert box.css == custom
+        # Preset rules suppressed.
+        assert "column-count" not in box.css
+
+    def test_padding_emitted(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(layout="grid-2x2", padding="0.5in")
+        assert "padding: 0.5in" in box.css
+
+    def test_auto_wrap_bare_content_into_block(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        md = ContentMarkdown(content="# hi")
+        box = ContentPageBox(content=[md])
+        assert len(box.content) == 1
+        assert isinstance(box.content[0], ContentPageBlock)
+        # The block wraps the original content as its single child.
+        assert box.content[0].content[0] is md
+
+    def test_auto_wrap_preserves_existing_blocks(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        block = ContentPageBlock(content=[ContentMarkdown(content="a")], span=2)
+        box = ContentPageBox(content=[block])
+        # Existing block passes through verbatim.
+        assert box.content[0] is block
+        assert box.content[0].span == 2
+
+    def test_auto_wrap_mixed_children(self):
+        from nbprint.config.content import (
+            ContentMarkdown,
+            ContentPageBlock,
+            ContentPageBox,
+        )
+
+        md = ContentMarkdown(content="a")
+        block = ContentPageBlock(content=[ContentMarkdown(content="b")])
+        box = ContentPageBox(content=[md, block])
+        # First child auto-wrapped; second passes through.
+        assert isinstance(box.content[0], ContentPageBlock)
+        assert box.content[1] is block
+
+    def test_auto_wrap_does_not_apply_to_string_content(self):
+        from nbprint.config.content import ContentPageBox
+
+        box = ContentPageBox(content="raw cell source")
+        assert box.content == "raw cell source"
+
+    def test_layout_invalid_raises(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from nbprint.config.content import ContentPageBox
+
+        with pytest.raises(ValidationError):
+            ContentPageBox(layout="not-a-real-preset")
+
+    def test_nbprint_page_runtime_passes_layout(self):
+        from nbprint import NBPrintPage
+
+        page = NBPrintPage(emit=False, layout="grid-2x2", gap="1rem", padding="0.5in")
+        d = page.to_dict()
+        assert d["layout"] == "grid-2x2"
+        assert d["gap"] == "1rem"
+        assert d["padding"] == "0.5in"


### PR DESCRIPTION
ContentPageBox layout system:

* New `layout` field with presets: flow (default), columns-2, columns-3, grid-2x2, grid-3x2, grid-3x3, grid (bare display:grid for named-area templates), flex-row, flex-column, inline, masonry, custom (suppresses preset CSS so the user owns :scope).
* New gap / padding / align / justify knobs that compose with every preset and pass through to_dict() so notebook authors get the same composability via the NBPrintPage runtime.
* Preset CSS is only generated when `css` is the default; user-supplied CSS still fully overrides.
* New `nbprint/config/content/_layout_presets.py` holds the shared CSS constants (FLEX_ROW_CSS, FLEX_COLUMN_CSS, INLINE_CSS, PAGE_BOX_BASE_CSS) — both ContentPageBox and the existing ContentFlex / InlineLayout containers consume them so layout CSS has a single source of truth.

Auto-wrap:

* `model_validator(mode="after")` on ContentPageBox wraps any bare `Content` child in a `ContentPageBlock` so the rendered DOM shape is always page-box > block > <user>. Existing `ContentPageBlock` children pass through unchanged; string content (single-cell runtime use) is left alone.

Named-area grids:

* New optional `grid_template` field accepting raw CSS grid-template (rows + track sizes). A validator extracts area names from quoted row strings (ignoring the '.' placeholder) and cross-checks every child `ContentPageBlock.area` is defined; unused template areas are allowed.
* Emitted as `:scope { grid-template: ... }` appended to the preset CSS so it composes with layout="grid" / "grid-2x2" / etc.
* `NBPrintPage` runtime forwards `grid_template` through `to_dict()` for parity with YAML.

NBPrintBlock runtime context manager:

* New `nbprint.config.block_runtime` module exporting `NBPrintBlock` and `NBPRINT_BLOCK_MIME` (`application/nbprint.block+json`).
* Mirrors `NBPrintPage`: emits a hidden MIME on `__enter__`, ingestion in `Configuration._extract_nbprint_mime` now iterates over (page, block) MIME tuple and dispatches by `type_`.
* Accepts every `ContentPageBlock` field (section, span, rows, area, aspect, min_height, max_height, break_inside, scalable, css, style, classname, attrs, ignore).

Tests:

* 36 new unit tests in `nbprint/tests/test_sections.py` (TestPageBoxLayout, TestPageBoxGridTemplate, TestNBPrintBlock) covering every preset, gap / padding / align / justify projection, custom override, user-css override, the auto-wrap matrix (bare / existing / mixed / string content), grid_template area validation, and NBPrintBlock metadata round-trip. Full unit sweep: 213 passed.
* New Playwright fixtures `js/tests/fixtures/page_box/columns-2.html`, `grid-2x2.html`, `named-areas.html` plus 12 e2e assertions verifying computed column-count, display:grid, grid-template-columns track count, span=2 width vs siblings, and named-area placement (hero / chart / table). All page-box e2e tests pass.

Docs:

* `docs/src/architecture.md` gains a layout-preset table, an auto-wrap explainer with YAML + hydra-CLI examples, a "Named-area grids" subsection, and a "Runtime API: NBPrintPage and NBPrintBlock" section with an end-to-end notebook example.
