### PR TITLE
Add page-box layout visual coverage

### DIFF
--- a/examples/notebook-page-boxes.ipynb
+++ b/examples/notebook-page-boxes.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f449d3fe",
+   "metadata": {},
+   "source": [
+    "# Page-Box Layout Demo\n",
+    "\n",
+    "Exercises the `NBPrintPage` runtime API with several layout presets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "018fd634",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "from nbprint import NBPrintPage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25169177",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flow layout (default stacking)\n",
+    "with NBPrintPage(layout=\"flow\", gap=\"0.3in\"):\n",
+    "    display(Markdown(\"## Flow Block 1\\n\\nFirst block in flow layout.\"))\n",
+    "    display(Markdown(\"## Flow Block 2\\n\\nSecond block stacked below.\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fc4a89d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Two-column layout\n",
+    "with NBPrintPage(layout=\"columns-2\", gap=\"0.25in\"):\n",
+    "    display(Markdown(\"### Col A\\n\\nLeft column content.\"))\n",
+    "    display(Markdown(\"### Col B\\n\\nRight column content.\"))\n",
+    "    display(Markdown(\"### Col C\\n\\nThird block wraps.\"))\n",
+    "    display(Markdown(\"### Col D\\n\\nFourth block.\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ef8dae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grid 2x2 layout\n",
+    "with NBPrintPage(layout=\"grid-2x2\", gap=\"0.2in\"):\n",
+    "    display(Markdown(\"### Top-Left\\n\\nQuadrant 1.\"))\n",
+    "    display(Markdown(\"### Top-Right\\n\\nQuadrant 2.\"))\n",
+    "    display(Markdown(\"### Bottom-Left\\n\\nQuadrant 3.\"))\n",
+    "    display(Markdown(\"### Bottom-Right\\n\\nQuadrant 4.\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5993ae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flex-row layout\n",
+    "with NBPrintPage(layout=\"flex-row\", gap=\"0.15in\"):\n",
+    "    display(Markdown(\"**A**\"))\n",
+    "    display(Markdown(\"**B**\"))\n",
+    "    display(Markdown(\"**C**\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f217ccab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Three-column layout\n",
+    "with NBPrintPage(layout=\"columns-3\", gap=\"0.2in\"):\n",
+    "    display(Markdown(\"### 1\\n\\nColumn one.\"))\n",
+    "    display(Markdown(\"### 2\\n\\nColumn two.\"))\n",
+    "    display(Markdown(\"### 3\\n\\nColumn three.\"))\n",
+    "    display(Markdown(\"### 4\\n\\nOverflow block.\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8b527d5",
+   "metadata": {},
+   "source": [
+    "## End\n",
+    "\n",
+    "All page-box layout presets exercised successfully."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/js/tests/fixtures/page_box/columns-2.html
+++ b/js/tests/fixtures/page_box/columns-2.html
@@ -27,6 +27,12 @@ body.jp-Notebook { margin: 0; padding: 0 !important; }
   column-fill: balance;
   column-gap: 0.5in;
 }
+[data-nbprint-page-box="box-cols"] > [data-nbprint-block] {
+  display: flow-root;
+}
+[data-nbprint-page-box="box-cols"] > [data-nbprint-block] > :first-child {
+  margin-top: 0;
+}
 [data-nbprint-block] {
   break-inside: avoid;
   min-width: 0;

--- a/js/tests/fixtures/page_box/columns-3.html
+++ b/js/tests/fixtures/page_box/columns-3.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=columns-3</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="columns-3", gap="0.25in"). */
+[data-nbprint-page-box="box-cols3"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: block;
+  min-height: 100%;
+  column-count: 3;
+  column-fill: balance;
+  column-gap: 0.25in;
+}
+[data-nbprint-page-box="box-cols3"] > [data-nbprint-block] {
+  display: flow-root;
+}
+[data-nbprint-page-box="box-cols3"] > [data-nbprint-block] > :first-child {
+  margin-top: 0;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-cols3"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="columns-3">
+    <div class="jp-Cell" data-nbprint-block="c1" data-nbprint-break-inside="avoid">
+      <h2>Block 1</h2>
+      <p>First block in a three-column layout.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="c2" data-nbprint-break-inside="avoid">
+      <h2>Block 2</h2>
+      <p>Second block, balanced across columns.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="c3" data-nbprint-break-inside="avoid">
+      <h2>Block 3</h2>
+      <p>Third block in the three-column layout.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="c4" data-nbprint-break-inside="avoid">
+      <h2>Block 4</h2>
+      <p>Fourth block wrapping into the next row.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="c5" data-nbprint-break-inside="avoid">
+      <h2>Block 5</h2>
+      <p>Fifth block — demonstrates balanced fill.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="c6" data-nbprint-break-inside="avoid">
+      <h2>Block 6</h2>
+      <p>Sixth block across three columns.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/flex-column.html
+++ b/js/tests/fixtures/page_box/flex-column.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=flex-column</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="flex-column", gap="0.25in"). */
+[data-nbprint-page-box="box-flexcol"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  gap: 0.25in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+  border: 1px solid #999;
+  padding: 0.25rem;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-flexcol"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="flex-column">
+    <div class="jp-Cell" data-nbprint-block="fc1" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Top</h2>
+      <p>Flex column items are laid out vertically with explicit flex layout.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="fc2" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Middle</h2>
+      <p>Unlike flow layout, flex column allows align/justify controls.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="fc3" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Bottom</h2>
+      <p>Third item stacked vertically.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/flex-row.html
+++ b/js/tests/fixtures/page_box/flex-row.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=flex-row</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="flex-row", gap="0.25in"). */
+[data-nbprint-page-box="box-flexrow"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: flex;
+  flex-direction: row;
+  min-height: 100%;
+  gap: 0.25in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  border: 1px solid #999;
+  padding: 0.25rem;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-flexrow"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="flex-row">
+    <div class="jp-Cell" data-nbprint-block="fr1" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Left</h2>
+      <p>Flex row items are laid out horizontally.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="fr2" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Center</h2>
+      <p>Each block takes equal width by default.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="fr3" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Right</h2>
+      <p>Three items side by side in a row.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/flow.html
+++ b/js/tests/fixtures/page_box/flow.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=flow</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="flow", gap="0.5in"). */
+[data-nbprint-page-box="box-flow"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: block;
+  min-height: 100%;
+}
+[data-nbprint-page-box="box-flow"] > .jp-Cell + .jp-Cell {
+  margin-top: 0.5in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-flow"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="flow">
+    <div class="jp-Cell" data-nbprint-block="f1" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Block 1</h2>
+      <p>First block in a flow layout. Blocks stack vertically with a 0.5in gap.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="f2" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Block 2</h2>
+      <p>Second block, separated by the gap margin.</p>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="f3" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h2>Block 3</h2>
+      <p>Third block. Flow layout is the default — blocks are stacked like normal document flow.</p>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/fixtures/page_box/grid-3x3.html
+++ b/js/tests/fixtures/page_box/grid-3x3.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Fixture: ContentPageBox layout=grid-3x3</title>
+<script>
+var _nbprint_configuration = { pagedjs: true, debug: false, page: "{\"orientation\": null, \"size\": null}" };
+var _nbprint_notebook_info = new Map();
+window.FontAwesomeConfig = { searchPseudoElements: true };
+</script>
+<script type="module" src="/js/dist/embedded.js"></script>
+<link rel="stylesheet" href="/js/dist/css/embedded.css" />
+<link rel="stylesheet" href="/js/dist/css/index.css" />
+<style>
+body.jp-Notebook { margin: 0; padding: 0 !important; }
+@page { margin: 0.5in; }
+/* Mimic ContentPageBox(layout="grid-3x3", gap="0.15in"). */
+[data-nbprint-page-box="box-grid33"] {
+  break-before: page;
+  break-after: page;
+  break-inside: auto;
+  display: grid;
+  min-height: 100%;
+  grid-auto-flow: row dense;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.15in;
+}
+[data-nbprint-block] {
+  break-inside: avoid;
+  min-width: 0;
+  min-height: 0;
+  border: 1px dashed #666;
+  padding: 0.25rem;
+}
+</style>
+</head>
+<body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
+<main>
+  <div class="jp-Cell"
+       data-nbprint-page-box="box-grid33"
+       data-nbprint-fit="scale"
+       data-nbprint-layout="grid-3x3">
+    <div class="jp-Cell" data-nbprint-block="t1" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>1,1</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t2" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>1,2</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t3" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>1,3</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t4" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>2,1</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t5" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>2,2</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t6" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>2,3</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t7" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>3,1</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t8" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>3,2</h3>
+    </div>
+    <div class="jp-Cell" data-nbprint-block="t9" data-nbprint-break-inside="avoid"
+         style="break-inside: avoid">
+      <h3>3,3</h3>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/js/tests/page_box.spec.js
+++ b/js/tests/page_box.spec.js
@@ -9,6 +9,10 @@ async function getPages(page) {
   return page.locator(".pagedjs_page").all();
 }
 
+function renderedBlock(page, id) {
+  return page.locator(`.pagedjs_pages [data-nbprint-block="${id}"]`).first();
+}
+
 test.describe("ContentPageBox layout presets — Phase 9.4", () => {
   test.describe("layout=columns-2", () => {
     test.beforeEach(async ({ page }) => {
@@ -45,6 +49,18 @@ test.describe("ContentPageBox layout presets — Phase 9.4", () => {
         );
         expect(breakInside).toBe("avoid");
       }
+    });
+
+    test("columns start on the same visual baseline", async ({ page }) => {
+      const firstColumn = await renderedBlock(page, "b1").boundingBox();
+      const secondColumn = await renderedBlock(page, "b3").boundingBox();
+      expect(Math.abs(firstColumn.y - secondColumn.y)).toBeLessThan(2);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-columns-2.png", {
+        fullPage: true,
+      });
     });
   });
 
@@ -86,6 +102,210 @@ test.describe("ContentPageBox layout presets — Phase 9.4", () => {
       const siblingBox = await sibling.boundingBox();
       expect(spannedBox.width).toBeGreaterThan(siblingBox.width * 1.5);
     });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-grid-2x2.png", {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe("layout=flow", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/flow.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box reflects layout attribute", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-flow"]').first();
+      await expect(box).toHaveAttribute("data-nbprint-layout", "flow");
+    });
+
+    test("page-box uses display: block", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-flow"]').first();
+      const display = await box.evaluate((el) => getComputedStyle(el).display);
+      expect(display).toBe("block");
+    });
+
+    test("blocks stack vertically with gap", async ({ page }) => {
+      const b1 = page.locator('[data-nbprint-block="f1"]').first();
+      const b2 = page.locator('[data-nbprint-block="f2"]').first();
+      const box1 = await b1.boundingBox();
+      const box2 = await b2.boundingBox();
+      // b2 starts below b1
+      expect(box2.y).toBeGreaterThan(box1.y + box1.height - 1);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-flow.png", {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe("layout=flex-row", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/flex-row.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box reflects layout attribute", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-flexrow"]').first();
+      await expect(box).toHaveAttribute("data-nbprint-layout", "flex-row");
+    });
+
+    test("page-box uses display: flex with row direction", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-flexrow"]').first();
+      const display = await box.evaluate((el) => getComputedStyle(el).display);
+      expect(display).toBe("flex");
+      const direction = await box.evaluate(
+        (el) => getComputedStyle(el).flexDirection,
+      );
+      expect(direction).toBe("row");
+    });
+
+    test("blocks sit side by side", async ({ page }) => {
+      const fr1 = page.locator('[data-nbprint-block="fr1"]').first();
+      const fr2 = page.locator('[data-nbprint-block="fr2"]').first();
+      const fr3 = page.locator('[data-nbprint-block="fr3"]').first();
+      const box1 = await fr1.boundingBox();
+      const box2 = await fr2.boundingBox();
+      const box3 = await fr3.boundingBox();
+      // Same row: similar y, increasing x
+      expect(Math.abs(box1.y - box2.y)).toBeLessThan(5);
+      expect(box2.x).toBeGreaterThan(box1.x);
+      expect(box3.x).toBeGreaterThan(box2.x);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-flex-row.png", {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe("layout=flex-column", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/flex-column.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box uses display: flex with column direction", async ({
+      page,
+    }) => {
+      const box = page.locator('[data-nbprint-page-box="box-flexcol"]').first();
+      const display = await box.evaluate((el) => getComputedStyle(el).display);
+      expect(display).toBe("flex");
+      const direction = await box.evaluate(
+        (el) => getComputedStyle(el).flexDirection,
+      );
+      expect(direction).toBe("column");
+    });
+
+    test("blocks stack vertically", async ({ page }) => {
+      const fc1 = page.locator('[data-nbprint-block="fc1"]').first();
+      const fc2 = page.locator('[data-nbprint-block="fc2"]').first();
+      const box1 = await fc1.boundingBox();
+      const box2 = await fc2.boundingBox();
+      expect(box2.y).toBeGreaterThan(box1.y + box1.height - 1);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-flex-column.png", {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe("layout=columns-3", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/columns-3.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("computed column-count is 3", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-cols3"]').first();
+      const count = await box.evaluate(
+        (el) => getComputedStyle(el).columnCount,
+      );
+      expect(count).toBe("3");
+    });
+
+    test("six blocks survive pagination", async ({ page }) => {
+      const blocks = await page.locator("[data-nbprint-block]").all();
+      expect(blocks.length).toBeGreaterThanOrEqual(6);
+    });
+
+    test("columns start on the same visual baseline", async ({ page }) => {
+      const firstColumn = await renderedBlock(page, "c1").boundingBox();
+      const secondColumn = await renderedBlock(page, "c3").boundingBox();
+      const thirdColumn = await renderedBlock(page, "c5").boundingBox();
+      expect(Math.abs(firstColumn.y - secondColumn.y)).toBeLessThan(2);
+      expect(Math.abs(firstColumn.y - thirdColumn.y)).toBeLessThan(2);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-columns-3.png", {
+        fullPage: true,
+      });
+    });
+  });
+
+  test.describe("layout=grid-3x3", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/page_box/grid-3x3.html");
+      await waitForPagedJS(page);
+    });
+
+    test("renders at least one page", async ({ page }) => {
+      const pages = await getPages(page);
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    test("page-box uses display: grid", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-grid33"]').first();
+      const display = await box.evaluate((el) => getComputedStyle(el).display);
+      expect(display).toBe("grid");
+    });
+
+    test("grid-template-columns has three equal tracks", async ({ page }) => {
+      const box = page.locator('[data-nbprint-page-box="box-grid33"]').first();
+      const tracks = await box.evaluate(
+        (el) => getComputedStyle(el).gridTemplateColumns,
+      );
+      expect(tracks.split(/\s+/).filter(Boolean).length).toBe(3);
+    });
+
+    test("nine blocks present", async ({ page }) => {
+      const blocks = await page.locator("[data-nbprint-block]").all();
+      expect(blocks.length).toBe(9);
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-grid-3x3.png", {
+        fullPage: true,
+      });
+    });
   });
 
   test.describe("layout=grid + grid_template (named areas)", () => {
@@ -125,6 +345,12 @@ test.describe("ContentPageBox layout presets — Phase 9.4", () => {
         const el = page.locator(`[data-nbprint-area="${area}"]`).first();
         await expect(el).toHaveAttribute("data-nbprint-area", area);
       }
+    });
+
+    test("visual regression", async ({ page }) => {
+      await expect(page).toHaveScreenshot("layout-named-areas.png", {
+        fullPage: true,
+      });
     });
   });
 });

--- a/js/tests/page_box.spec.js-snapshots/layout-columns-2.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-columns-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e4489049610efa9adb1dea22630f05165a9dacc8185c76d1b3182c8e9adc54c
+size 41219

--- a/js/tests/page_box.spec.js-snapshots/layout-columns-3.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-columns-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb6a04f957ed74d9fd427b2f50c234e2c06bd94a19d25d32796487e228f3f76f
+size 25752

--- a/js/tests/page_box.spec.js-snapshots/layout-flex-column.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-flex-column.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d58692b666624c182fc716a107605adcc68e9b81a55e5385c11554aef52046a9
+size 22540

--- a/js/tests/page_box.spec.js-snapshots/layout-flex-row.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-flex-row.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e16aac8ba37d71ef785ba23cab020fbb1f6e4765e1b0359eb179b1af92cd0888
+size 17734

--- a/js/tests/page_box.spec.js-snapshots/layout-flow.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-flow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d9fb10668ac0dd6fa9fb02d28a8ce8e38e31c38d14148db604ed24381929962
+size 25559

--- a/js/tests/page_box.spec.js-snapshots/layout-grid-2x2.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-grid-2x2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a0787fc5b7cccb07ac2b6604964ff75af1a9a38f58356a089ccf1c53ec40268
+size 16993

--- a/js/tests/page_box.spec.js-snapshots/layout-grid-3x3.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-grid-3x3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88bd11cc67aa2abbca8eff0553f8ee4a26d1ec087c5f38b97080fb7e87f4e662
+size 16838

--- a/js/tests/page_box.spec.js-snapshots/layout-named-areas.png
+++ b/js/tests/page_box.spec.js-snapshots/layout-named-areas.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b420e4d647f9ac7963b6aab8b6930da9e9238748270c6ff2f29a4dc51b5137a
+size 13661

--- a/nbprint/config/content/_layout_presets.py
+++ b/nbprint/config/content/_layout_presets.py
@@ -81,7 +81,10 @@ def _columns_builder(count: int) -> _Builder:
             rules.append(f"column-gap: {gap};")
         if padding is not None:
             rules.append(f"padding: {padding};")
-        return _scope_block(rules)
+        scope = _scope_block(rules)
+        scope += ":scope > [data-nbprint-block] { display: flow-root; }\n"
+        scope += ":scope > [data-nbprint-block] > :first-child { margin-top: 0; }\n"
+        return scope
 
     return build
 

--- a/nbprint/tests/test_e2e.py
+++ b/nbprint/tests/test_e2e.py
@@ -31,6 +31,7 @@ _integration_notebooks = (
     "notebook-sections",
     "notebook-runtime",
     "notebook-overlays",
+    "notebook-page-boxes",
 )
 _integration_formats = (
     "ipynb",

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -1421,6 +1421,8 @@ class TestPageBoxLayout:
 
         box = ContentPageBox(layout="columns-2")
         assert "column-count: 2" in box.css
+        assert "> [data-nbprint-block] { display: flow-root" in box.css
+        assert "> [data-nbprint-block] > :first-child { margin-top: 0" in box.css
         assert box.attrs["data-nbprint-layout"] == "columns-2"
 
     def test_columns_3_emits_column_count(self):
@@ -1429,6 +1431,8 @@ class TestPageBoxLayout:
         box = ContentPageBox(layout="columns-3", gap="0.5in")
         assert "column-count: 3" in box.css
         assert "column-gap: 0.5in" in box.css
+        assert "> [data-nbprint-block] { display: flow-root" in box.css
+        assert "> [data-nbprint-block] > :first-child { margin-top: 0" in box.css
 
     def test_grid_2x2_emits_grid_template(self):
         from nbprint.config.content import ContentPageBox


### PR DESCRIPTION
Add Playwright fixtures and snapshots for page-box layout presets, register a notebook e2e case, and normalize column block margins so multi-column baselines align.
