### PR TITLE
feat(content): list-of-lists middlematter chapters with title pages

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -195,6 +195,46 @@ content:
 
 Flat-list `content:` is still fully supported — it is treated as `middlematter`.
 
+### Chapters (list-of-lists middlematter)
+
+For multi-chapter documents, supply `middlematter` as a **list of lists**. Each
+sublist is a chapter: its **first element** is promoted to a chapter separator
+and the remaining elements form the chapter body. nbprint interleaves them in
+document order — `[chapter1-title, *chapter1-body, chapter2-title, *chapter2-body, …]`.
+
+```yaml
+content:
+  middlematter:
+    - # Chapter One — first item becomes the title page
+      - _target_: nbprint.ContentMarkdown
+        content: "# Chapter One"
+      - _target_: nbprint.ContentMarkdown
+        content: "Body of the first chapter…"
+
+    - # Chapter Two
+      - _target_: nbprint.ContentMarkdown
+        content: "# Chapter Two"
+      - _target_: nbprint.ContentMarkdown
+        content: "Body of the second chapter…"
+```
+
+By default each separator renders as a **standalone chapter title page** — a hard
+page break is inserted before and after it. To keep separators inline with their
+chapter body instead, disable the behavior:
+
+```yaml
+content:
+  separator_title_pages: false
+  middlematter:
+    - [...]
+```
+
+The promoted separators are also available directly under the
+`middlematter_separators` section if you prefer to populate them explicitly
+alongside a flat `middlematter` list.
+
+See `examples/chapters.yaml` for a full working example.
+
 ### Per-section page layout
 
 Each section can carry its own page layout via `PageGlobal.pages`. This generates CSS `@page <section> { ... }` rules and maps cells to them via `data-nbprint-section` attributes:

--- a/examples/chapters.yaml
+++ b/examples/chapters.yaml
@@ -1,0 +1,77 @@
+---
+# Chapters example — demonstrates list-of-lists ``middlematter``.
+#
+# Each sublist under ``middlematter`` is a chapter. Its FIRST element is
+# promoted to a chapter separator and rendered as a standalone title page
+# (a hard page break before and after it); the remaining elements are the
+# chapter body. nbprint interleaves them as:
+#
+#   [chap1-title, *chap1-body, chap2-title, *chap2-body, ...]
+#
+# Set ``content.separator_title_pages: false`` to keep separators inline
+# instead of giving them their own page.
+debug: false
+outputs:
+  _target_: nbprint.NBConvertOutputs
+  naming: "{{name}}"
+  root: ./outputs
+  target: "html"
+
+page:
+  _target_: nbprint.PageGlobal
+  bottom_right:
+    _target_: nbprint.PageRegion
+    content:
+      _target_: nbprint.PageNumber
+
+content:
+  covermatter:
+    - _target_: nbprint.ContentMarkdown
+      content: |
+        # The nbprint Chronicles
+        ## A multi-chapter report
+      css: ":scope { text-align: center; }"
+
+  table_of_contents:
+    - _target_: nbprint.ContentTableOfContents
+
+  # List-of-lists: each sublist is a chapter. The first item of each
+  # sublist becomes a title page; the rest is the chapter body.
+  middlematter:
+    - # ── Chapter One ──────────────────────────────────────────────
+      - _target_: nbprint.ContentMarkdown
+        content: |
+          # Chapter One
+          ## Beginnings
+        css: ":scope { text-align: center; padding-top: 35%; }"
+      - _target_: nbprint.ContentMarkdown
+        content: |
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+          ## A Subsection
+          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+          nisi ut aliquip ex ea commodo consequat.
+
+    - # ── Chapter Two ──────────────────────────────────────────────
+      - _target_: nbprint.ContentMarkdown
+        content: |
+          # Chapter Two
+          ## Developments
+        css: ":scope { text-align: center; padding-top: 35%; }"
+      - _target_: nbprint.ContentMarkdown
+        content: |
+          Duis aute irure dolor in reprehenderit in voluptate velit esse
+          cillum dolore eu fugiat nulla pariatur.
+
+          ## Another Subsection
+          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+          officia deserunt mollit anim id est laborum.
+
+  endmatter:
+    - _target_: nbprint.ContentPageBreak
+    - _target_: nbprint.ContentMarkdown
+      content: |
+        # Bibliography
+        1. Author A. "Title of Work." Publisher, 2024.
+        2. Author B. "Another Work." Publisher, 2025.

--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -111,19 +111,36 @@ class Configuration(CallableModel, BaseModel):
         return BaseModel._to_type(v, Context)
 
     @staticmethod
-    def _convert_content_from_list(v) -> ContentMarshall:
+    def _coerce_content_list(v: list) -> list:
+        """Coerce the elements of a content list into :class:`Content` objects.
+
+        Strings become ``Content`` placeholders and ``_target_`` dicts are
+        instantiated. Nested lists (list-of-lists ``middlematter``, where each
+        sublist is a chapter whose first element becomes a separator) are
+        coerced recursively so the chapter structure survives long enough for
+        :class:`ContentMarshall` to extract the separators.
+        """
         for i, element in enumerate(v):
             if isinstance(element, str):
                 v[i] = Content(type_=element)
             elif isinstance(element, dict):
                 v[i] = BaseModel._to_type(element)
-        return ContentMarshall(middlematter=v)
+            elif isinstance(element, list):
+                v[i] = Configuration._coerce_content_list(element)
+        return v
+
+    @staticmethod
+    def _convert_content_from_list(v) -> ContentMarshall:
+        return ContentMarshall(middlematter=Configuration._coerce_content_list(v))
 
     @staticmethod
     def _convert_content_from_dict(v) -> ContentMarshall:
         for key in ContentMarshall.model_fields:
             if key in v and isinstance(v[key], list):
-                v[key] = Configuration._convert_content_from_list(v[key]).all
+                # Preserve a list-of-lists ``middlematter`` (chapter structure)
+                # so ContentMarshall can promote each sublist's first item to a
+                # separator. Flat lists are coerced element-wise as before.
+                v[key] = Configuration._coerce_content_list(v[key])
         return ContentMarshall(**v)
 
     @field_validator("content", mode="before")

--- a/nbprint/config/core/content.py
+++ b/nbprint/config/core/content.py
@@ -6,7 +6,7 @@ from nbprint.config.base import BaseModel
 from nbprint.config.common import Style
 from nbprint.config.content import Content, ContentTableOfContents
 
-__all__ = ("SECTION_GROUPS", "SECTION_ORDER", "ContentMarshall", "Section")
+__all__ = ("SECTION_GROUPS", "SECTION_ORDER", "SEPARATOR_TITLE_PAGE_CSS", "ContentMarshall", "Section")
 
 
 """
@@ -88,6 +88,13 @@ SECTION_GROUPS: dict[str, str] = {
 }
 
 
+# CSS that turns a middlematter separator into a standalone chapter title
+# page: it always starts on a fresh page and the following chapter body
+# starts on the next page. Scoped to ``:scope`` so the ``@scope(...)``
+# wrapper emitted by the template targets the separator cell.
+SEPARATOR_TITLE_PAGE_CSS = ":scope {\n  break-before: page;\n  break-after: page;\n}"
+
+
 class ContentMarshall(BaseModel):
     # Prematter
     prematter: list[Content] = Field(
@@ -155,6 +162,15 @@ class ContentMarshall(BaseModel):
         description=("Per-chapter item counts for middlematter when supplied as a list-of-lists. Populated automatically; rarely set by hand."),
     )
 
+    # When True, every entry in ``middlematter_separators`` is rendered as a
+    # standalone chapter title page (a hard page break before and after the
+    # separator cell). Disable to keep separators inline with their chapter
+    # body, or to supply your own break CSS per separator.
+    separator_title_pages: bool = Field(
+        default=True,
+        description="Render each middlematter separator as a standalone chapter title page (break-before/break-after page).",
+    )
+
     _all: list[Content] = PrivateAttr(default_factory=list)
     _prematter: list[Content] = PrivateAttr(default_factory=list)
     _covermatter: list[Content] = PrivateAttr(default_factory=list)
@@ -205,6 +221,11 @@ class ContentMarshall(BaseModel):
         if self.auto_table_of_contents and not self.table_of_contents:
             self.table_of_contents = [ContentTableOfContents()]
 
+        # Render chapter separators as standalone title pages when requested.
+        if self.separator_title_pages:
+            for sep in self.middlematter_separators:
+                self._apply_title_page_css(sep)
+
         # Populate per-group aggregations
         self._prematter = self.prematter
         self._covermatter = self.covermatter
@@ -216,6 +237,21 @@ class ContentMarshall(BaseModel):
         # Full document order
         self._all = self._prematter + self._covermatter + self._frontmatter + self._middlematter + self._endmatter + self._rearmatter
         return self
+
+    @staticmethod
+    def _apply_title_page_css(separator: Content) -> None:
+        """Merge the standalone title-page break CSS into a separator's ``css``.
+
+        Idempotent: the break rule is only appended when it is not already
+        present, so repeated validation never duplicates it. Any CSS the
+        separator already carries is preserved.
+        """
+        if not isinstance(separator, Content):
+            return
+        existing = separator.css if isinstance(separator.css, str) else ""
+        if "break-before: page" in existing:
+            return
+        separator.css = f"{existing}\n{SEPARATOR_TITLE_PAGE_CSS}" if existing else SEPARATOR_TITLE_PAGE_CSS
 
     def _compose_middlematter(self) -> list[Content]:
         """Build middlematter in render order.

--- a/nbprint/tests/test_e2e.py
+++ b/nbprint/tests/test_e2e.py
@@ -24,6 +24,7 @@ _integration_templates = (
     "customsize",
     "nonpagedjs",
     "greattables",
+    "chapters",
 )
 _integration_notebooks = (
     "basic",

--- a/nbprint/tests/test_sections.py
+++ b/nbprint/tests/test_sections.py
@@ -155,6 +155,96 @@ class TestContentMarshall:
         cm = ContentMarshall(middlematter=[a, b], middlematter_separators=[sep])
         assert [c.content for c in cm._middlematter] == ["a", "b", "sep"]
 
+    def test_separator_title_page_css_applied_by_default(self):
+        """Separators render as standalone title pages (break-before/after) by default."""
+        c1_sep = ContentMarkdown(content="chap1-title")
+        c1_a = ContentMarkdown(content="chap1-a")
+        cm = ContentMarshall(middlematter=[[c1_sep, c1_a]])
+        sep_css = cm.middlematter_separators[0].css
+        assert "break-before: page" in sep_css
+        assert "break-after: page" in sep_css
+        # chapter body must not get the title-page break
+        assert "break-before: page" not in (cm.middlematter[0].css or "")
+
+    def test_separator_title_page_css_disabled(self):
+        """separator_title_pages=False leaves separator css untouched."""
+        c1_sep = ContentMarkdown(content="chap1-title")
+        c1_a = ContentMarkdown(content="chap1-a")
+        cm = ContentMarshall(middlematter=[[c1_sep, c1_a]], separator_title_pages=False)
+        assert "break-before: page" not in (cm.middlematter_separators[0].css or "")
+
+    def test_separator_title_page_css_preserves_existing(self):
+        """Existing separator css is preserved when the break rule is appended."""
+        sep = ContentMarkdown(content="chap1-title", css=":scope { color: red; }")
+        body = ContentMarkdown(content="chap1-a")
+        cm = ContentMarshall(middlematter=[[sep, body]])
+        sep_css = cm.middlematter_separators[0].css
+        assert "color: red" in sep_css
+        assert "break-before: page" in sep_css
+
+    def test_separator_title_page_css_idempotent(self):
+        """Re-validating an already-configured marshall does not duplicate the break rule."""
+        c1_sep = ContentMarkdown(content="chap1-title")
+        c1_a = ContentMarkdown(content="chap1-a")
+        cm = ContentMarshall(middlematter=[[c1_sep, c1_a]])
+        # Re-run the after-validator by constructing from a dump
+        cm2 = ContentMarshall.model_validate(cm)
+        sep_css = cm2.middlematter_separators[0].css
+        assert sep_css.count("break-before: page") == 1
+
+    def test_middlematter_list_of_lists_via_dict_loader(self):
+        """Configuration loader preserves list-of-lists chapters from a content dict (YAML path)."""
+        from nbprint.config.core.config import Configuration
+
+        cm = Configuration._convert_content_from_dict(
+            {
+                "middlematter": [
+                    [
+                        {"_target_": "nbprint.ContentMarkdown", "content": "# Chapter 1"},
+                        {"_target_": "nbprint.ContentMarkdown", "content": "c1 body"},
+                    ],
+                    [
+                        {"_target_": "nbprint.ContentMarkdown", "content": "# Chapter 2"},
+                        {"_target_": "nbprint.ContentMarkdown", "content": "c2 body"},
+                    ],
+                ]
+            }
+        )
+        assert [c.content for c in cm.middlematter_separators] == ["# Chapter 1", "# Chapter 2"]
+        assert [c.content for c in cm.middlematter] == ["c1 body", "c2 body"]
+        assert cm.middlematter_chapter_sizes == [1, 1]
+        assert [c.content for c in cm._middlematter] == ["# Chapter 1", "c1 body", "# Chapter 2", "c2 body"]
+
+    def test_middlematter_list_of_lists_via_list_loader(self):
+        """Bare-list content loader also preserves list-of-lists chapters."""
+        from nbprint.config.core.config import Configuration
+
+        cm = Configuration._convert_content_from_list(
+            [
+                [
+                    {"_target_": "nbprint.ContentMarkdown", "content": "# Chapter 1"},
+                    {"_target_": "nbprint.ContentMarkdown", "content": "c1 body"},
+                ],
+                [
+                    {"_target_": "nbprint.ContentMarkdown", "content": "# Chapter 2"},
+                ],
+            ]
+        )
+        assert [c.content for c in cm._middlematter] == ["# Chapter 1", "c1 body", "# Chapter 2"]
+
+    def test_flat_list_loader_backward_compat(self):
+        """Flat content list still lands entirely in middlematter."""
+        from nbprint.config.core.config import Configuration
+
+        cm = Configuration._convert_content_from_list(
+            [
+                {"_target_": "nbprint.ContentMarkdown", "content": "a"},
+                {"_target_": "nbprint.ContentMarkdown", "content": "b"},
+            ]
+        )
+        assert [c.content for c in cm._middlematter] == ["a", "b"]
+        assert cm.middlematter_chapter_sizes is None
+
     def test_auto_table_of_contents_injects_when_empty(self):
         """auto_table_of_contents=True injects a ContentTableOfContents when section is empty."""
         from nbprint.config.content import ContentTableOfContents
@@ -271,6 +361,7 @@ class TestSectionConstants:
             "section_styles",
             "auto_table_of_contents",
             "middlematter_chapter_sizes",
+            "separator_title_pages",
         }
 
     def test_section_groups_keys_match_order(self):


### PR DESCRIPTION
Make the list-of-lists middlematter feature work through the actual config loaders and render chapter separators as standalone title pages.

- Loader: `_convert_content_from_list`/`_convert_content_from_dict` now recurse into sublists via a shared `_coerce_content_list` helper, so a list-of-lists `middlematter` survives YAML/dict ingestion instead of being flattened. Previously the chapter structure only worked when constructing `ContentMarshall` directly in Python.
- ContentMarshall: new `separator_title_pages` field (default True) injects idempotent `break-before/after: page` CSS onto each promoted separator so chapters open on a fresh title page; existing separator CSS is preserved. Exported `SEPARATOR_TITLE_PAGE_CSS`.
- Example: `examples/chapters.yaml` demonstrates the two-chapter list-of-lists syntax; wired into the Python e2e template matrix.
- Docs: new "Chapters (list-of-lists middlematter)" section in docs/src/configuration.md.
- Tests: 7 new unit tests covering the loader paths (dict/list/flat) and the title-page CSS (applied/disabled/preserves-existing/idempotent).
