### PR TITLE
Cap oversized images by their layout container

### DIFF
--- a/js/src/js/preprocessing/measure.js
+++ b/js/src/js/preprocessing/measure.js
@@ -138,7 +138,12 @@ function scaleOversizedImages(contentRoot, contentArea) {
     const h = img.naturalHeight || attrH || 0;
 
     if (w > contentArea.width || h > contentArea.height) {
-      img.style.maxWidth = contentArea.width + "px";
+      // Cap by the container as well as the page. An inline pixel width beats every stylesheet rule,
+      // so setting the page content width alone lets an image inside a narrower container - a page-box
+      // column, a grid cell, a flex row - grow past that container and overlap its neighbour. The
+      // percentage resolves against whatever box the image actually sits in, and the pixel term keeps
+      // a full-width image within the page. Matches the SVG and .jp-RenderedImage branches below.
+      img.style.maxWidth = `min(100%, ${contentArea.width}px)`;
       img.style.maxHeight = contentArea.height + "px";
       img.style.objectFit = "contain";
 

--- a/js/tests/fixtures/overflow/oversized-image-in-columns.html
+++ b/js/tests/fixtures/overflow/oversized-image-in-columns.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fixture: Oversized Image In Columns</title>
+    <script>
+      var _nbprint_configuration = {
+        pagedjs: true,
+        debug: false,
+        page: '{"orientation": null, "size": null}',
+      };
+      var _nbprint_notebook_info = new Map();
+      window.FontAwesomeConfig = { searchPseudoElements: true };
+    </script>
+    <script type="module" src="/js/dist/embedded.js"></script>
+    <link rel="stylesheet" href="/js/dist/css/embedded.css" />
+    <link rel="stylesheet" href="/js/dist/css/index.css" />
+    <style>
+      body.jp-Notebook {
+        margin: 0;
+        padding: 0 !important;
+      }
+      @page {
+        margin: 0.5in;
+      }
+      /* Mimic the CSS that ContentPageBox(layout="columns-2", gap="0.5in")
+   emits via build_page_box_css(). Letter minus 0.5in margins gives a
+   720px content area, so each of the two columns is (720 - 48) / 2 = 336px. */
+      [data-nbprint-page-box="box-cols"] {
+        break-before: page;
+        break-after: page;
+        break-inside: auto;
+        display: block;
+        min-height: 100%;
+        column-count: 2;
+        column-fill: balance;
+        column-gap: 0.5in;
+      }
+      [data-nbprint-page-box="box-cols"] > [data-nbprint-block] {
+        display: flow-root;
+      }
+      [data-nbprint-block] {
+        break-inside: avoid;
+        min-width: 0;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body
+    class="jp-Notebook"
+    data-jp-theme-light="true"
+    data-jp-theme-name="JupyterLab Light"
+  >
+    <main>
+      <div
+        class="jp-Cell"
+        data-nbprint-page-box="box-cols"
+        data-nbprint-fit="scale"
+        data-nbprint-layout="columns-2"
+      >
+        <div
+          class="jp-Cell"
+          data-nbprint-block="b1"
+          data-nbprint-break-inside="avoid"
+        >
+          <div class="jp-Cell-outputWrapper">
+            <div class="jp-OutputArea jp-Cell-outputArea">
+              <div class="jp-OutputArea-output jp-RenderedImage">
+                <!-- 1500x1000 chart, wider than the 720px page content area, so preprocessing scales it -->
+                <img
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1500' height='1000'%3E%3Crect width='1500' height='1000' fill='%234a90d9'/%3E%3Ctext x='750' y='500' text-anchor='middle' fill='white' font-size='80'%3EChart A (1500x1000)%3C/text%3E%3C/svg%3E"
+                  alt="chart a"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="jp-Cell"
+          data-nbprint-block="b2"
+          data-nbprint-break-inside="avoid"
+        >
+          <div class="jp-Cell-outputWrapper">
+            <div class="jp-OutputArea jp-Cell-outputArea">
+              <div class="jp-OutputArea-output jp-RenderedImage">
+                <img
+                  src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1500' height='1000'%3E%3Crect width='1500' height='1000' fill='%23d94a90'/%3E%3Ctext x='750' y='500' text-anchor='middle' fill='white' font-size='80'%3EChart B (1500x1000)%3C/text%3E%3C/svg%3E"
+                  alt="chart b"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/js/tests/structural.spec.js
+++ b/js/tests/structural.spec.js
@@ -347,6 +347,29 @@ test.describe("Pre-pagination preprocessing", () => {
     }
   });
 
+  test("oversized image is capped by its column, not the page", async ({
+    page,
+  }) => {
+    // Scaling wrote the page content width as an inline max-width, which outranks every stylesheet
+    // rule, so an image in a two-column page box grew to full page width and overlapped its
+    // neighbour. Each column here is (720 - 48) / 2 = 336px.
+    await page.goto(
+      "/js/tests/fixtures/overflow/oversized-image-in-columns.html",
+    );
+    await waitForPagedJS(page);
+    const result = await page.evaluate(() => {
+      return [...document.querySelectorAll("img")].map((img) => ({
+        rendered: Math.round(img.getBoundingClientRect().width),
+        container: Math.round(img.parentElement.getBoundingClientRect().width),
+      }));
+    });
+    expect(result.length).toBeGreaterThan(0);
+    for (const { rendered, container } of result) {
+      expect(rendered).toBeLessThanOrEqual(container + 1);
+      expect(rendered).toBeLessThan(500);
+    }
+  });
+
   test("tall table gets annotated and split into chunks", async ({ page }) => {
     await page.goto("/js/tests/fixtures/overflow/long-table.html");
     await waitForPagedJS(page);


### PR DESCRIPTION
Pre-pagination scaling wrote the page content width onto every oversized image as an inline max-width. An inline style outranks any stylesheet rule, so an image sitting inside a narrower container - a page-box column, a grid cell, a flex row - was free to grow to the full page width and overlap its neighbour. The only way to claw it back was a per-cell `:scope img { max-width: 100% !important }`, which is exactly the hand-rolled CSS the page-box layout overlays were meant to retire.

Use `min(100%, <page>px)` instead: the percentage resolves against whatever box the image actually sits in, so a narrower container wins, while the pixel term still keeps a full-width image inside the page. This brings images in line with the SVG and .jp-RenderedImage branches, which already constrained by percentage.

Covered by a two-column page-box fixture whose columns are 336px wide. Against the previous behaviour the image rendered at 720px; it is now capped by its column. A downstream report carrying 36 copies of the workaround CSS dropped every one of them and rendered identically - same page count, same 261pt chart width.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [ ] Linting passes (`make lint`)
- [ ] Tests pass (`make test`)
- [ ] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)
