### PR TITLE
Keep section headings clear of the cell above them

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,7 @@
     "start:tests": "http-server -p 3000 ..",
     "start:examples": "http-server -p 3000 -o examples/",
     "test": "TZ=UTC playwright test",
-    "test:structural": "TZ=UTC playwright test tests/structural.spec.js",
+    "test:structural": "TZ=UTC playwright test tests/structural.spec.js tests/typography.spec.js",
     "test:integration": "TZ=UTC playwright test --config integration.config.js"
   },
   "publishConfig": {

--- a/js/src/css/index.css
+++ b/js/src/css/index.css
@@ -75,13 +75,27 @@
   /* padding-left: 0px !important; */
   /* padding-right: 0px !important; */
 }
+/* Leading headings in a cell.
+
+   A section heading is almost always the only content of its own cell, so the
+   heading is the first child of its rendered-markdown container and this rule
+   matches it. Zeroing the margin outright is wrong: it welds the heading to
+   whatever cell precedes it, which for a report is usually a chart. Spacing the
+   heading itself is the only reliable handle, because nbprint emits a per-cell
+   <script> and <style> between cell wrappers and Paged.js strips the scripts
+   while paginating, so no sibling selector reaches the preceding cell.
+
+   The default of 0 preserves the historical behaviour. Set
+   --nbprint-heading-spacing to give section headings room to breathe; the
+   postprocessing pass then zeroes it again on whichever heading leads a page,
+   so an opted-in document does not indent its headings below the top margin. */
 .pagedjs_page .jp-RenderedHTMLCommon h1:first-child,
 .pagedjs_page .jp-RenderedHTMLCommon h2:first-child,
 .pagedjs_page .jp-RenderedHTMLCommon h3:first-child,
 .pagedjs_page .jp-RenderedHTMLCommon h4:first-child,
 .pagedjs_page .jp-RenderedHTMLCommon h5:first-child,
 .pagedjs_page .jp-RenderedHTMLCommon h6:first-child {
-  margin-top: 0px !important;
+  margin-top: var(--nbprint-heading-spacing, 0px) !important;
 }
 .pagedjs_page .jp-RenderedHTMLCommon h1:last-child,
 .pagedjs_page .jp-RenderedHTMLCommon h2:last-child,

--- a/js/src/js/postprocessing/validate.js
+++ b/js/src/js/postprocessing/validate.js
@@ -156,6 +156,48 @@ function checkMinPages() {
 }
 
 /**
+ * Drop the leading-heading spacing on whichever heading starts a page.
+ *
+ * `--nbprint-heading-spacing` keeps a section heading clear of the cell above
+ * it, but that space is wrong at the top of a page, where it indents the
+ * heading below the page margin. CSS cannot express "first rendered thing on
+ * the page": `:first-child` sees the zero-height and non-rendered siblings
+ * Paged.js leaves behind, and the depth of the wrapper chain varies with the
+ * document. Walking the laid-out pages is exact, and it runs after pagination
+ * so it cannot perturb the layout it is measuring.
+ *
+ * @returns {number} how many headings were trimmed.
+ */
+function trimLeadingHeadingMargins() {
+  const HEADINGS = new Set(["H1", "H2", "H3", "H4", "H5", "H6"]);
+  let trimmed = 0;
+
+  for (const page of document.querySelectorAll(".pagedjs_page")) {
+    const area = page.querySelector(".pagedjs_page_content");
+    if (!area) continue;
+
+    // Descend through the wrapper chain to the first element that actually
+    // occupies space, then take its leading heading, if it has one.
+    let node = area;
+    while (node) {
+      const next = [...node.children].find((child) => {
+        const box = child.getBoundingClientRect();
+        return box.width > 0 && box.height > 0;
+      });
+      if (!next) break;
+      if (HEADINGS.has(next.tagName)) {
+        next.style.setProperty("margin-top", "0", "important");
+        trimmed += 1;
+        break;
+      }
+      node = next;
+    }
+  }
+
+  return trimmed;
+}
+
+/**
  * Run post-pagination validation and repair.
  *
  * @param {object} configuration  The _nbprint_configuration object.
@@ -181,6 +223,13 @@ export function postvalidate(configuration) {
   for (const { id, want, got } of checkMinPages()) {
     console.warn(
       `[nbprint] postprocessing: page-box ${id} asked for ${want} page(s) but produced ${got}`,
+    );
+  }
+
+  const headingsTrimmed = trimLeadingHeadingMargins();
+  if (headingsTrimmed > 0) {
+    console.debug(
+      `[nbprint] postprocessing: trimmed leading margin on ${headingsTrimmed} page-leading heading(s)`,
     );
   }
 

--- a/js/tests/fixtures/typography/heading-spacing.html
+++ b/js/tests/fixtures/typography/heading-spacing.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fixture: Heading Spacing</title>
+    <script>
+      var _nbprint_configuration = {
+        pagedjs: true,
+        debug: false,
+        page: '{"orientation": null, "size": null}',
+      };
+      var _nbprint_notebook_info = new Map();
+      window.FontAwesomeConfig = { searchPseudoElements: true };
+    </script>
+    <script type="module" src="/js/dist/embedded.js"></script>
+    <link rel="stylesheet" href="/js/dist/css/embedded.css" />
+    <link rel="stylesheet" href="/js/dist/css/index.css" />
+    <style>
+      body.jp-Notebook {
+        margin: 0;
+        padding: 0 !important;
+      }
+      @page {
+        margin: 0.5in;
+      }
+      /* Opt in to heading spacing. 18pt == 24px at 96dpi. */
+      :root {
+        --nbprint-heading-spacing: 18pt;
+      }
+      /* Stand-in for a rendered chart, sized so pagination is deterministic. */
+      .chart {
+        height: 200px;
+        background: #dde;
+      }
+      [data-nbprint-id="heading-pagetop"] {
+        break-before: page;
+      }
+    </style>
+  </head>
+  <body
+    class="jp-Notebook"
+    data-jp-theme-light="true"
+    data-jp-theme-name="JupyterLab Light"
+  >
+    <main>
+      <!-- Chart, then a heading-only markdown cell. The heading must clear the
+           chart above it rather than sitting flush against it. -->
+      <div class="nbprint-cell" data-nbprint-id="chart-above">
+        <div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+          <div class="jp-Cell-outputWrapper">
+            <div class="jp-OutputArea jp-Cell-outputArea">
+              <div class="jp-OutputArea-child">
+                <div class="jp-RenderedHTMLCommon jp-OutputArea-output">
+                  <div class="chart"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="nbprint-cell" data-nbprint-id="heading-midpage">
+        <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+          <div class="jp-Cell-inputWrapper">
+            <div class="jp-InputArea jp-Cell-inputArea">
+              <div
+                class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput"
+              >
+                <h2 id="midpage-heading">Information Coefficient</h2>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="nbprint-cell" data-nbprint-id="chart-below">
+        <div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+          <div class="jp-Cell-outputWrapper">
+            <div class="jp-OutputArea jp-Cell-outputArea">
+              <div class="jp-OutputArea-child">
+                <div class="jp-RenderedHTMLCommon jp-OutputArea-output">
+                  <div class="chart"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- nbprint emits a per-cell <script> and <style> between cell wrappers.
+           They render nothing but they are element children, so any selector
+           built on :first-child sees them instead of the cell. -->
+      <script>
+        void 0;
+      </script>
+      <style></style>
+
+      <!-- A forced break, so the next heading starts a page. It must NOT carry
+           the spacing - otherwise it sits indented below the top page margin.
+           This is the case a sibling-position selector gets wrong. -->
+      <div class="nbprint-cell" data-nbprint-id="heading-pagetop">
+        <div class="jp-Cell jp-MarkdownCell jp-Notebook-cell">
+          <div class="jp-Cell-inputWrapper">
+            <div class="jp-InputArea jp-Cell-inputArea">
+              <div
+                class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput"
+              >
+                <h2 id="pagetop-heading">Key Findings</h2>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="nbprint-cell" data-nbprint-id="chart-last">
+        <div class="jp-Cell jp-CodeCell jp-Notebook-cell">
+          <div class="jp-Cell-outputWrapper">
+            <div class="jp-OutputArea jp-Cell-outputArea">
+              <div class="jp-OutputArea-child">
+                <div class="jp-RenderedHTMLCommon jp-OutputArea-output">
+                  <div class="chart"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/js/tests/typography.spec.js
+++ b/js/tests/typography.spec.js
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+async function waitForPagedJS(page, timeout = 30000) {
+  await page.waitForSelector(".pagedjs_pages", { timeout });
+  await page.waitForTimeout(500);
+}
+
+// 18pt of heading spacing is 24px at 96dpi.
+const SPACING_PX = 24;
+
+test.describe("Heading spacing", () => {
+  test.describe("opted in via --nbprint-heading-spacing", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/js/tests/fixtures/typography/heading-spacing.html");
+      await waitForPagedJS(page);
+    });
+
+    test("a mid-page heading clears the cell above it", async ({ page }) => {
+      const gap = await page.evaluate(() => {
+        const chart = document.querySelector(
+          '[data-nbprint-id="chart-above"] .chart',
+        );
+        const heading = document.querySelector("#midpage-heading");
+        return (
+          heading.getBoundingClientRect().top -
+          chart.getBoundingClientRect().bottom
+        );
+      });
+      expect(gap).toBeCloseTo(SPACING_PX, 0);
+    });
+
+    test("a page-leading heading is not indented below the page margin", async ({
+      page,
+    }) => {
+      const offset = await page.evaluate(() => {
+        const heading = document.querySelector("#pagetop-heading");
+        const area = heading.closest(".pagedjs_page_content");
+        return (
+          heading.getBoundingClientRect().top - area.getBoundingClientRect().top
+        );
+      });
+      expect(offset).toBeCloseTo(0, 0);
+    });
+
+    test("the trim is applied to the heading, not the wrapper", async ({
+      page,
+    }) => {
+      const margins = await page.evaluate(() => ({
+        midpage: getComputedStyle(document.querySelector("#midpage-heading"))
+          .marginTop,
+        pagetop: getComputedStyle(document.querySelector("#pagetop-heading"))
+          .marginTop,
+      }));
+      expect(margins.midpage).toBe(`${SPACING_PX}px`);
+      expect(margins.pagetop).toBe("0px");
+    });
+  });
+
+  test("defaults to no spacing when the property is unset", async ({
+    page,
+  }) => {
+    await page.goto("/js/tests/fixtures/overflow/orphaned-heading.html");
+    await waitForPagedJS(page);
+
+    const margins = await page.evaluate(() =>
+      [
+        ...document.querySelectorAll(
+          ".pagedjs_page .jp-RenderedHTMLCommon :is(h1,h2,h3,h4,h5,h6):first-child",
+        ),
+      ].map((h) => getComputedStyle(h).marginTop),
+    );
+
+    expect(margins.length).toBeGreaterThan(0);
+    for (const margin of margins) {
+      expect(margin).toBe("0px");
+    }
+  });
+});


### PR DESCRIPTION
## Description

`index.css` zeroed `margin-top` outright on a leading heading, which welded every section heading to whatever cell preceded it — in a report, usually a chart. A heading is essentially always the first child of its own cell's `.jp-RenderedHTMLCommon`, so the rule fired on every heading rather than only on the page-top case it was written for. A downstream report measured the resulting gap at 0.0pt across five pages.

Spacing is now driven by `--nbprint-heading-spacing`, **defaulting to `0px`, so no existing document changes**. Opting in gives section headings room to breathe.

The page-top correction cannot be expressed in CSS, and that is worth spelling out because the obvious approaches were tried and fail:

- `:first-child` is not "first rendered thing on the page" — Paged.js leaves zero-height and non-rendered siblings behind, and the depth of the wrapper chain varies per document.
- A sibling combinator cannot reach the preceding chart, because nbprint emits a per-cell `<script>` and `<style>` between cell wrappers and Paged.js strips the scripts while paginating.

So `postprocessing/validate.js` gains a small pass that walks each laid-out page down to the first element that actually occupies space and trims the margin there. It runs after pagination, so it cannot perturb the layout it measures.

Also wires `tests/typography.spec.js` into `test:structural`: `make test` only ran `structural.spec.js`, so the new tests would otherwise never run in CI.