### PR TITLE
Warn when an overlay or a reserved tag does nothing

### DIFF
--- a/nbprint/config/core/config.py
+++ b/nbprint/config/core/config.py
@@ -21,7 +21,14 @@ from nbprint.config.common import Style
 from nbprint.config.content import Content, ContentCode, ContentMarkdown
 from nbprint.config.exceptions import NBPrintPathIsYamlError, NBPrintPathOrModelMalformedError
 from nbprint.config.magic import _parse_magic_line
-from nbprint.config.overlay import LayoutOverlay, Overlay, apply_layout_overlays, apply_overlays, build_layout_overlay
+from nbprint.config.overlay import (
+    LayoutOverlay,
+    Overlay,
+    apply_layout_overlays,
+    apply_overlays,
+    build_layout_overlay,
+    describe_matcher,
+)
 from nbprint.config.page_runtime import NBPRINT_PAGE_MIME
 
 from .content import SECTION_ORDER, ContentMarshall
@@ -39,6 +46,28 @@ _log = getSimpleLogger("nbprint.config.core.config")
 
 
 _SECTION_TAG_PREFIX = "nbprint:section:"
+
+# Tags nbprint reserves for itself. Anything under the namespace that is not one
+# of these is inert, and almost always a typo. Split in two because a bare
+# prefix test would accept "nbprint:pagebox" as the reserved tag "nbprint:page".
+_RESERVED_TAG_NAMESPACE = "nbprint:"
+_RESERVED_TAGS = frozenset(
+    {
+        "nbprint:config",
+        "nbprint:content",
+        "nbprint:context",
+        "nbprint:outputs",
+        "nbprint:page",
+        "nbprint:parameters",
+    }
+)
+_RESERVED_TAG_PREFIXES = (
+    "nbprint:content:",
+    "nbprint:output:",
+    "nbprint:page:",
+    "nbprint:section:",
+    "nbprint:section-group:",
+)
 
 
 class Configuration(CallableModel, BaseModel):
@@ -405,8 +434,10 @@ class Configuration(CallableModel, BaseModel):
         layout_overlays: list[LayoutOverlay] = [build_layout_overlay(spec) for spec in raw_layouts if isinstance(spec, (LayoutOverlay, dict))]
 
         placements: list = [None] * len(cells_to_process)
+        matched_overlays: set[int] = set()
 
         for i, cell in enumerate(cells_to_process):
+            Configuration._warn_on_unconsumed_tags(cell, index=i)
             cell_instance = Configuration._cell_to_content(cell)
             if cell_instance is not None:
                 # Route cell to the appropriate section based on tags/metadata.
@@ -422,10 +453,14 @@ class Configuration(CallableModel, BaseModel):
                 target_section = section or "middlematter"
 
                 # Apply formatting overlays
-                apply_overlays(overlays, cell=cell, content=cell_instance, index=i, section=target_section)
+                matched_overlays.update(id(o) for o in apply_overlays(overlays, cell=cell, content=cell_instance, index=i, section=target_section))
 
                 getattr(values["content"], target_section).append(cell_instance)
                 placements[i] = (target_section, cell_instance)
+
+        for overlay in overlays:
+            if id(overlay) not in matched_overlays:
+                _log.warning(f"overlay ({describe_matcher(overlay.match)}) matched no cells; its formatting was not applied anywhere")
 
         # Apply layout-wrapping overlays after all cells are placed.
         if layout_overlays:
@@ -436,6 +471,32 @@ class Configuration(CallableModel, BaseModel):
                 setattr(values["parameters"], k, v)
             elif isinstance(values["parameters"], PapermillParameters) and (k not in values["parameters"].vars or values["parameters"].vars[k] is None):
                 values["parameters"].vars[k] = v
+
+    @staticmethod
+    def _warn_on_unconsumed_tags(cell, index: int) -> None:
+        """Flag reserved-namespace cell tags that nbprint will not act on.
+
+        A tag in the ``nbprint:`` namespace looks authoritative, so a typo in
+        one is silently inert: the cell simply renders as though the tag were
+        never there.  Both cases here are unambiguous authoring mistakes, and
+        both used to cost the author a render cycle to notice.
+        """
+        tags = cell.get("metadata", {}).get("tags", []) if hasattr(cell, "get") else []
+        for tag in tags:
+            if not tag.startswith(_RESERVED_TAG_NAMESPACE):
+                continue
+            if tag.startswith(_SECTION_TAG_PREFIX):
+                name = tag[len(_SECTION_TAG_PREFIX) :]
+                if name not in SECTION_ORDER:
+                    _log.warning(
+                        f"cell {index} is tagged {tag!r} but {name!r} is not a section; "
+                        f"it will fall back to middlematter. Known sections: {', '.join(SECTION_ORDER)}"
+                    )
+                continue
+            if tag in _RESERVED_TAGS:
+                continue
+            if not any(tag.startswith(prefix) for prefix in _RESERVED_TAG_PREFIXES):
+                _log.warning(f"cell {index} carries reserved tag {tag!r}, which nbprint does not consume")
 
     @model_validator(mode="before")
     @classmethod

--- a/nbprint/config/overlay.py
+++ b/nbprint/config/overlay.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Iterable, Literal
 
+from pkn import getSimpleLogger
 from pydantic import Field, model_validator
 
 from nbprint.config.base import BaseModel
@@ -28,6 +29,23 @@ from nbprint.config.content.page_box import ContentPageBox, PageBoxFit, PageBoxL
 from nbprint.config.core.content import SECTION_ORDER, Section
 
 __all__ = ("CellMatcher", "LayoutOverlay", "Overlay", "PageBoxOverlay")
+
+_log = getSimpleLogger("nbprint.config.overlay")
+
+
+def describe_matcher(matcher: CellMatcher) -> str:
+    """Render a matcher's set criteria for a diagnostic message."""
+    criteria = {
+        name: value
+        for name, value in (
+            ("index", matcher.index),
+            ("tag", matcher.tag),
+            ("cell_type", matcher.cell_type),
+            ("section", matcher.section),
+        )
+        if value is not None
+    }
+    return ", ".join(f"{k}={v!r}" for k, v in criteria.items()) or "<matches every cell>"
 
 
 class CellMatcher(BaseModel):
@@ -124,17 +142,21 @@ class Overlay(BaseModel):
         )
 
 
-def apply_overlays(overlays: list[Overlay], cell, content, index: int, section: str | None) -> None:
+def apply_overlays(overlays: list[Overlay], cell, content, index: int, section: str | None) -> list[Overlay]:
     """Apply all matching overlays from ``overlays`` to ``content``.
 
     Overlays are applied in list order; later overlays layer on top of earlier
-    ones.
+    ones.  Returns the overlays that matched, so the caller can tell which of
+    them never matched anything across the whole notebook.
     """
     if not overlays:
-        return
+        return []
+    matched = []
     for overlay in overlays:
         if overlay.match.matches(cell=cell, index=index, section=section):
             overlay.apply(content)
+            matched.append(overlay)
+    return matched
 
 
 class LayoutOverlay(BaseModel):
@@ -330,6 +352,7 @@ def apply_layout_overlays(
                 matched.append(i)
 
         if not matched:
+            _log.warning(f"layout overlay ({describe_matcher(lo.match)}) matched no cells; the cells it was meant to wrap will render unlaid-out")
             continue
 
         # Group into contiguous runs (consecutive notebook indices, same section)

--- a/nbprint/tests/test_overlay_diagnostics.py
+++ b/nbprint/tests/test_overlay_diagnostics.py
@@ -1,0 +1,132 @@
+"""Tests for the ingestion-time diagnostics that flag inert authoring.
+
+An overlay that matches nothing, or a reserved-namespace tag nbprint does not
+consume, both render exactly like a correct document minus the formatting.
+These warnings are the only signal an author gets.
+"""
+
+import logging
+
+from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+
+from nbprint import CellMatcher, LayoutOverlay, Overlay, PageBoxOverlay
+from nbprint.config.core.config import Configuration
+from nbprint.config.core.content import ContentMarshall
+from nbprint.config.overlay import describe_matcher
+
+
+def ingest(caplog, *, cells, **values):
+    """Run cell ingestion and return the warnings it emitted."""
+    nb = new_notebook()
+    nb.cells = cells
+    values.setdefault("content", ContentMarshall())
+    with caplog.at_level(logging.WARNING):
+        Configuration._process_cells(values, nb)
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestOverlayMatchedNothing:
+    def test_formatting_overlay_matching_no_cells_warns(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["present"]})],
+            overlays=[Overlay(match=CellMatcher(tag="absent"), css=":scope { color: red; }")],
+        )
+        assert any("matched no cells" in w and "'absent'" in w for w in warnings)
+
+    def test_formatting_overlay_that_matches_is_quiet(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["present"]})],
+            overlays=[Overlay(match=CellMatcher(tag="present"), css=":scope { color: red; }")],
+        )
+        assert not any("matched no cells" in w for w in warnings)
+
+    def test_layout_overlay_matching_no_cells_warns(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["present"]})],
+            layout_overlays=[LayoutOverlay(match=CellMatcher(tag="absent"), layout="row")],
+        )
+        assert any("layout overlay" in w and "matched no cells" in w for w in warnings)
+
+    def test_page_box_overlay_matching_no_cells_warns(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["present"]})],
+            layout_overlays=[PageBoxOverlay(match=CellMatcher(tag="absent"), layout="columns-2")],
+        )
+        assert any("layout overlay" in w and "matched no cells" in w for w in warnings)
+
+    def test_layout_overlay_that_matches_is_quiet(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[
+                new_markdown_cell(source="A", metadata={"tags": ["pair"]}),
+                new_markdown_cell(source="B", metadata={"tags": ["pair"]}),
+            ],
+            layout_overlays=[LayoutOverlay(match=CellMatcher(tag="pair"), layout="row")],
+        )
+        assert not any("matched no cells" in w for w in warnings)
+
+    def test_only_the_unmatched_overlay_is_reported(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["present"]})],
+            overlays=[
+                Overlay(match=CellMatcher(tag="present"), css=":scope { color: red; }"),
+                Overlay(match=CellMatcher(tag="absent"), css=":scope { color: blue; }"),
+            ],
+        )
+        reported = [w for w in warnings if "matched no cells" in w]
+        assert len(reported) == 1
+        assert "'absent'" in reported[0]
+
+
+class TestReservedTags:
+    def test_unknown_section_tag_warns(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["nbprint:section:frontmater"]})],
+        )
+        assert any("frontmater" in w and "not a section" in w for w in warnings)
+
+    def test_known_section_tag_is_quiet(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_markdown_cell(source="A", metadata={"tags": ["nbprint:section:frontmatter"]})],
+        )
+        assert not any("not a section" in w for w in warnings)
+
+    def test_unconsumed_reserved_tag_warns(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_code_cell(source="x = 1", metadata={"tags": ["nbprint:pagebox"]})],
+        )
+        assert any("nbprint:pagebox" in w and "does not consume" in w for w in warnings)
+
+    def test_plain_tags_are_never_flagged(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[new_code_cell(source="x = 1", metadata={"tags": ["pair-ic", "chart"]})],
+        )
+        assert not any("does not consume" in w for w in warnings)
+
+    def test_recognised_reserved_prefixes_are_quiet(self, caplog):
+        warnings = ingest(
+            caplog,
+            cells=[
+                new_code_cell(source="x = 1", metadata={"tags": ["nbprint:content:cover"]}),
+                new_code_cell(source="y = 2", metadata={"tags": ["nbprint:page"]}),
+                new_code_cell(source="z = 3", metadata={"tags": ["nbprint:output:pdf"]}),
+            ],
+        )
+        assert not any("does not consume" in w for w in warnings)
+
+
+class TestDescribeMatcher:
+    def test_lists_only_the_criteria_that_are_set(self):
+        assert describe_matcher(CellMatcher(tag="ic", cell_type="code")) == "tag='ic', cell_type='code'"
+
+    def test_empty_matcher_is_described_as_matching_everything(self):
+        assert describe_matcher(CellMatcher()) == "<matches every cell>"


### PR DESCRIPTION
## Description

A layout overlay that matches no cells renders its cells full width and says nothing. A mistyped tag in the `nbprint:` namespace is inert in exactly the same silent way — the cell renders as though the tag were never there. Both are unambiguous authoring mistakes with no diagnostic today, and both have cost a downstream report a full render cycle to notice, twice.

Three warnings at ingestion:

- a formatting `Overlay` that matched no cell anywhere in the notebook;
- a `LayoutOverlay` / `PageBoxOverlay` that matched no cells;
- a cell tag under `nbprint:` that nbprint does not consume, including `nbprint:section:<name>` naming a section that does not exist (which silently falls back to middlematter).

`apply_overlays` now returns the overlays that matched, so ingestion can accumulate across cells and report the ones that never matched anywhere. It previously returned `None`; nothing outside `_process_cells` calls it.
