### PR TITLE
Support running elements and cover-page region suppression

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -20,7 +20,7 @@
     "start:tests": "http-server -p 3000 ..",
     "start:examples": "http-server -p 3000 -o examples/",
     "test": "TZ=UTC playwright test",
-    "test:structural": "TZ=UTC playwright test tests/structural.spec.js tests/typography.spec.js",
+    "test:structural": "TZ=UTC playwright test tests/structural.spec.js tests/typography.spec.js tests/page_regions.spec.js",
     "test:integration": "TZ=UTC playwright test --config integration.config.js"
   },
   "publishConfig": {

--- a/js/src/js/nbconvert.js
+++ b/js/src/js/nbconvert.js
@@ -347,6 +347,19 @@ export const build = async (configuration) => {
   // their styles before chunking or previewing
   document.body.classList.add("pagedjs");
 
+  // Page-level CSS is emitted as a per-cell <style> in the body, but Paged.js
+  // collects the stylesheets it will act on before it starts chunking. A rule
+  // left in the body is honoured for ordinary painting yet arrives too late for
+  // anything Paged.js has to register up front - `position: running()` most of
+  // all, whose element is silently left in the flow instead of being lifted
+  // into its margin box. Hoisting is enough; these rules are unscoped by the
+  // template already, so moving them cannot change what they match.
+  for (const style of document.querySelectorAll(
+    'style[data-nbprint-role="page"]',
+  )) {
+    document.head.appendChild(style);
+  }
+
   // Attach orientation class to body
   if (configuration.page.orientation) {
     document.body.setAttribute(

--- a/js/tests/fixtures/page_regions/running-element.html
+++ b/js/tests/fixtures/page_regions/running-element.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fixture: Page Regions</title>
+    <script>
+      var _nbprint_configuration = {
+        pagedjs: true,
+        debug: false,
+        page: '{"orientation": null, "size": null}',
+      };
+      var _nbprint_notebook_info = new Map();
+      window.FontAwesomeConfig = { searchPseudoElements: true };
+    </script>
+    <script type="module" src="/js/dist/embedded.js"></script>
+    <link rel="stylesheet" href="/js/dist/css/embedded.css" />
+    <link rel="stylesheet" href="/js/dist/css/index.css" />
+    <style>
+      body.jp-Notebook {
+        margin: 0;
+        padding: 0 !important;
+      }
+      @page {
+        margin: 0.5in;
+      }
+      /* Mimic exactly what PageGlobal emits for
+         bottom_left=PageRegion(content=RunningElement(name="footerLogo",
+         selector=".footer-logo")), bottom=PageRegion() and
+         suppress_first_page_regions=True. */
+      @page {
+        @bottom-left {
+          content: element(footerLogo);
+        }
+      }
+      @page {
+        @bottom-center {
+          content: counter(page);
+        }
+      }
+      .footer-logo {
+        position: running(footerLogo);
+      }
+      body:not(.pagedjs) .footer-logo {
+        display: none !important;
+      }
+      .pagedjs_first_page .pagedjs_margin-top,
+      .pagedjs_first_page .pagedjs_margin-bottom,
+      .pagedjs_first_page .pagedjs_margin-left,
+      .pagedjs_first_page .pagedjs_margin-right {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body
+    class="jp-Notebook"
+    data-jp-theme-light="true"
+    data-jp-theme-name="JupyterLab Light"
+  >
+    <main>
+      <!-- The running element. Lives in the body, gets lifted into the
+           bottom-left margin box of every page. -->
+      <div class="footer-logo" id="footer-logo">LOGO</div>
+
+      <div class="jp-Cell">
+        <div class="jp-Cell-outputWrapper">
+          <div class="jp-OutputArea jp-Cell-outputArea">
+            <div
+              class="jp-OutputArea-output jp-RenderedHTMLCommon"
+              id="content"
+            ></div>
+            <script>
+              // Enough prose to run past a single page, so first-page and
+              // later-page margin boxes can be compared.
+              const content = document.getElementById("content");
+              let html = "";
+              for (let i = 0; i < 60; i++) {
+                html +=
+                  "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                  "Sed do eiusmod tempor incididunt ut labore et dolore magna " +
+                  "aliqua. Ut enim ad minim veniam.</p>";
+              }
+              content.innerHTML = html;
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/js/tests/page_regions.spec.js
+++ b/js/tests/page_regions.spec.js
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+async function waitForPagedJS(page, timeout = 30000) {
+  await page.waitForSelector(".pagedjs_pages", { timeout });
+  await page.waitForTimeout(500);
+}
+
+test.describe("Page regions", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/js/tests/fixtures/page_regions/running-element.html");
+    await waitForPagedJS(page);
+  });
+
+  test("the document paginates onto more than one page", async ({ page }) => {
+    expect(await page.locator(".pagedjs_page").count()).toBeGreaterThan(1);
+  });
+
+  test("body carries the pagedjs marker the unpaginated-hiding rule keys off", async ({
+    page,
+  }) => {
+    await expect(page.locator("body")).toHaveClass(/\bpagedjs\b/);
+  });
+
+  test("the running element is lifted into a bottom-left margin box", async ({
+    page,
+  }) => {
+    const placed = await page.evaluate(
+      () =>
+        [...document.querySelectorAll(".footer-logo")].filter((el) =>
+          el.closest(".pagedjs_margin-bottom-left"),
+        ).length,
+    );
+    expect(placed).toBeGreaterThan(0);
+  });
+
+  test("the source element does not stay visible in the content flow", async ({
+    page,
+  }) => {
+    const leaked = await page.evaluate(() =>
+      [...document.querySelectorAll(".footer-logo")]
+        .filter((el) => el.closest(".pagedjs_page_content"))
+        .map((el) => getComputedStyle(el).display),
+    );
+    expect(leaked.every((display) => display === "none")).toBe(true);
+  });
+
+  test("margin boxes are hidden on the first page", async ({ page }) => {
+    const visible = await page.evaluate(() => {
+      const first = document.querySelector(".pagedjs_page");
+      return [...first.querySelectorAll(".pagedjs_margin-bottom")].map(
+        (el) => getComputedStyle(el).display,
+      );
+    });
+    expect(visible.length).toBeGreaterThan(0);
+    for (const display of visible) {
+      expect(display).toBe("none");
+    }
+  });
+
+  test("margin boxes still render on later pages", async ({ page }) => {
+    const displays = await page.evaluate(() => {
+      const pages = [...document.querySelectorAll(".pagedjs_page")];
+      const later = pages[1];
+      return [...later.querySelectorAll(".pagedjs_margin-bottom")].map(
+        (el) => getComputedStyle(el).display,
+      );
+    });
+    expect(displays.length).toBeGreaterThan(0);
+    expect(displays.some((d) => d !== "none")).toBe(true);
+  });
+
+  test("the page counter region is unaffected", async ({ page }) => {
+    const text = await page.evaluate(() => {
+      const pages = [...document.querySelectorAll(".pagedjs_page")];
+      const el = pages[1].querySelector(
+        ".pagedjs_margin-bottom-center .pagedjs_margin-content",
+      );
+      return el ? getComputedStyle(el, "::after").content : null;
+    });
+    expect(text).not.toBeNull();
+  });
+});

--- a/nbprint/config/core/page.py
+++ b/nbprint/config/core/page.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Iterator, Tuple
 
 from nbformat import NotebookNode
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from nbprint.config.base import BaseModel, Role, _append_or_extend
 from nbprint.config.common import PageOrientation, PageSize, Style
@@ -48,8 +48,23 @@ PAGE_REGION_ATTRS = (
     "right_bottom",
 )
 
+# The four edge regions whose CSS name is not their attribute name.
+_REGION_CSS_NAMES = {
+    "top": "top-center",
+    "bottom": "bottom-center",
+    "left": "left-center",
+    "right": "right-center",
+}
+
+
+def _region_css_name(attr: str) -> str:
+    return _REGION_CSS_NAMES.get(attr, attr.replace("_", "-"))
+
+
 if TYPE_CHECKING:
     from .config import Configuration
+
+_FIRST_PAGE_SUPPRESSION_MARKER = ".pagedjs_first_page .pagedjs_margin-"
 
 __all__ = (
     "Page",
@@ -57,6 +72,7 @@ __all__ = (
     "PageNumber",
     "PageRegion",
     "PageRegionContent",
+    "RunningElement",
 )
 
 
@@ -80,9 +96,56 @@ class PageRegionContent(BaseModel):
             v.append("nbprint:page")
         return v
 
+    def region_css(self) -> str:
+        """CSS this content needs *outside* its ``@page`` block.
+
+        Most region content is self-contained: a string, a counter. Content
+        sourced from the document body is not, because the source element has
+        to be styled where it lives.
+        """
+        return ""
+
 
 class PageNumber(PageRegionContent):
     content: str | None = "counter(page)"
+
+
+class RunningElement(PageRegionContent):
+    """Region content taken from an element that lives in the document body.
+
+    Paged.js lifts an element out of the flow when it carries
+    ``position: running(<name>)``, and a margin box pulls it back in with
+    ``content: element(<name>)``. Nothing here was expressible before, so every
+    consumer hand-rolled the pair -- and each one also had to rediscover that
+    the source element must be hidden when the document is *not* paginated,
+    since ``position: running()`` means nothing outside Paged.js and the element
+    would otherwise render inline in the body.
+
+    ``selector`` addresses the source element, e.g. ``.footer-logo``.
+    """
+
+    name: str
+    selector: str
+
+    @model_validator(mode="after")
+    def _default_content_to_the_element(self) -> "RunningElement":
+        if not self.content:
+            self.content = f"element({self.name})"
+        return self
+
+    def region_css(self) -> str:
+        # The `position: running()` rule has to be matchable against the parsed
+        # content fragment, because that is where Paged.js hides the source
+        # element (it sets an inline `display: none` on everything the rule
+        # selects). The fragment holds the body's *children*, so any selector
+        # rooted at `body` matches nothing there, the element is never hidden,
+        # and it paints in the normal flow while its clone appears in the margin
+        # box. For the same reason the rule must not force the element visible:
+        # a `display: block !important` here would outrank the inline
+        # `display: none` Paged.js relies on. Hiding for the unpaginated case is
+        # left to a `body`-rooted rule, which is only ever matched against the
+        # live document.
+        return f"\n{self.selector} {{ position: running({self.name}); }}\nbody:not(.pagedjs) {self.selector} {{ display: none !important; }}"
 
 
 class PageRegion(BaseModel):
@@ -131,10 +194,54 @@ class Page(BaseModel):
     counter_reset: bool = False
     counter_style: str | None = None
 
+    # The first page of a report is nearly always a cover, and a running footer
+    # or header across a cover looks like a mistake. Suppressing it is otherwise
+    # a hand-written rule against Paged.js' internal margin-box class names.
+    suppress_first_page_regions: bool = False
+
     size: PageSize | Tuple[float, float] | None = Field(default=PageSize.letter)
     orientation: PageOrientation | None = Field(default=PageOrientation.portrait)
 
     css: str = ""
+
+    @model_validator(mode="after")
+    def _assemble_page_css(self) -> "Page":
+        """Collect the CSS that has to sit outside any ``@page`` block or ``@scope``.
+
+        Two things land here rather than on the region itself. A region's CSS is
+        emitted as *cell* CSS, which the template wraps in ``@scope``, so a rule
+        addressing ``body`` or an element elsewhere in the document can never
+        match from there. And ``Configuration.page`` is typed as ``Page``, so a
+        consumer subclassing ``Page`` never reaches ``PageGlobal.render`` --
+        anything emitted only from there would silently do nothing for them.
+        """
+        for attr in PAGE_REGION_ATTRS:
+            region = getattr(self, attr, None)
+            if region is None or region.content is None:
+                continue
+
+            # A region handed over as a field default -- `bottom_left: PageRegion
+            # = Field(default=Footer())` on a Page subclass -- never passes
+            # through the `mode="before"` validator that names it and attaches
+            # its margin-box rule, because Pydantic does not validate defaults.
+            # Without that rule the box is never declared, so nothing consumes
+            # the region's content: a running element in particular is then left
+            # in the flow with no margin box to be lifted into. This validator
+            # does run for defaults, so it is the one place that can repair them.
+            region_name = _region_css_name(attr)
+            if not region._region:
+                region._region = region_name
+            if f"@{region_name} {{" not in region.css:
+                region.css += f"@page {{ @{region_name} {{ {region.content} }} }}"
+
+            extra = region.content.region_css()
+            if extra and extra not in self.css:
+                self.css += extra
+
+        if self.suppress_first_page_regions and _FIRST_PAGE_SUPPRESSION_MARKER not in self.css:
+            selectors = ", ".join(f".pagedjs_first_page .pagedjs_margin-{edge}" for edge in ("top", "bottom", "left", "right"))
+            self.css += f"\n{selectors} {{ display: none !important; }}"
+        return self
 
     @classmethod
     def convert_region_from_obj(cls, v, region) -> PageRegion:

--- a/nbprint/templates/nbprint/index.html.j2
+++ b/nbprint/templates/nbprint/index.html.j2
@@ -108,7 +108,7 @@ a.anchor-link {
         {% endif %}
     </script>
     {% if cell.metadata["nbprint"].get("css", None) %}
-    <style>
+    <style data-nbprint-role="{{ cell.metadata["nbprint"].get("role", "") }}">
         /* TODO should we make this like `ignore` as a first-order attribute? */
         {% if cell.metadata["nbprint"].get("role", "") not in ("configuration", "page") %}
         @scope (.{{ cell.metadata["nbprint"]["element_selector"] }}) {

--- a/nbprint/tests/test_page_regions.py
+++ b/nbprint/tests/test_page_regions.py
@@ -1,0 +1,120 @@
+"""Tests for page-region running elements and first-page region suppression."""
+
+from pydantic import Field
+
+from nbprint import PageGlobal, PageRegion, RunningElement
+from nbprint.config.core.page import PageNumber, PageRegionContent
+
+
+def make_page(**kwargs) -> PageGlobal:
+    page = PageGlobal(**kwargs)
+    page.render()
+    return page
+
+
+class TestRunningElement:
+    def test_content_defaults_to_the_named_element(self):
+        el = RunningElement(name="footerLogo", selector=".footer-logo")
+        assert el.content == "element(footerLogo)"
+
+    def test_explicit_content_is_left_alone(self):
+        el = RunningElement(name="footerLogo", selector=".footer-logo", content="element(other)")
+        assert el.content == "element(other)"
+
+    def test_margin_box_pulls_in_the_element(self):
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert "@bottom-left { content: element(footerLogo); }" in page.bottom_left.css
+
+    def test_source_element_is_made_running(self):
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert ".footer-logo { position: running(footerLogo); }" in page.css
+
+    def test_running_rule_is_not_rooted_at_body(self):
+        # Paged.js hides the source element by matching this rule against the
+        # parsed content fragment, which holds the body's children rather than
+        # the body itself. A body-rooted selector matches nothing there, so the
+        # element is never hidden and leaks into the flow.
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert "body.pagedjs .footer-logo { position: running" not in page.css
+
+    def test_running_rule_does_not_force_the_element_visible(self):
+        # Paged.js hides the source element with an inline `display: none`, which
+        # an !important declaration here would outrank.
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert "position: running(footerLogo); display: block !important;" not in page.css
+
+    def test_source_element_is_hidden_outside_pagedjs(self):
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert "body:not(.pagedjs) .footer-logo { display: none !important; }" in page.css
+
+    def test_source_css_is_page_level_not_region_level(self):
+        # A region's own CSS is emitted as cell CSS, which the template wraps in
+        # @scope; a rule addressing body from there can never match.
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert "position: running" not in page.bottom_left.css
+        assert "position: running" in page.css
+
+    def test_selector_is_used_verbatim(self):
+        page = make_page(top_right=PageRegion(content=RunningElement(name="mark", selector="#brand .mark")))
+        assert "#brand .mark { position: running(mark); }" in page.css
+        assert "body:not(.pagedjs) #brand .mark { display: none !important; }" in page.css
+
+    def test_source_css_is_not_duplicated(self):
+        page = make_page(bottom_left=PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+        assert page.css.count("position: running(footerLogo)") == 1
+
+
+class PageWithDefaultRegions(PageGlobal):
+    """A Page subclass supplying its regions the way a consumer does."""
+
+    bottom_left: PageRegion = Field(default_factory=lambda: PageRegion(content=RunningElement(name="footerLogo", selector=".footer-logo")))
+    bottom: PageRegion = Field(default_factory=PageRegion)
+    top_right_corner: PageRegion = Field(default_factory=PageRegion)
+
+
+class TestRegionsSuppliedAsDefaults:
+    """Regions set as Pydantic field defaults skip the `mode="before"` validators."""
+
+    def test_margin_box_rule_is_still_emitted(self):
+        page = PageWithDefaultRegions()
+        page.render()
+        assert "@bottom-left { content: element(footerLogo); }" in page.bottom_left.css
+
+    def test_region_is_named(self):
+        assert PageWithDefaultRegions().top_right_corner._region == "top-right-corner"
+
+    def test_edge_regions_keep_their_centre_names(self):
+        assert "@bottom-center { content: counter(page); }" in PageWithDefaultRegions().bottom.css
+
+    def test_corner_region_is_not_confused_with_its_edge(self):
+        assert "@top-right-corner { content: counter(page); }" in PageWithDefaultRegions().top_right_corner.css
+
+    def test_rule_is_not_duplicated_across_instances(self):
+        PageWithDefaultRegions()
+        assert PageWithDefaultRegions().bottom.css.count("@bottom-center") == 1
+
+
+class TestPlainRegionsUnaffected:
+    def test_page_number_region_emits_no_extra_css(self):
+        page = make_page(bottom=PageRegion())
+        assert page.bottom.css == "@page { @bottom-center { content: counter(page); } }"
+
+    def test_region_css_hook_defaults_to_empty(self):
+        assert PageRegionContent(content="x").region_css() == ""
+        assert PageNumber().region_css() == ""
+
+
+class TestFirstPageSuppression:
+    def test_off_by_default(self):
+        assert "pagedjs_first_page" not in make_page().css
+
+    def test_hides_every_margin_edge_on_the_first_page(self):
+        css = make_page(suppress_first_page_regions=True).css
+        for edge in ("top", "bottom", "left", "right"):
+            assert f".pagedjs_first_page .pagedjs_margin-{edge}" in css
+        assert "display: none !important;" in css
+
+    def test_render_is_idempotent(self):
+        page = make_page(suppress_first_page_regions=True)
+        page.render()
+        assert page.css.count(".pagedjs_first_page .pagedjs_margin-top") == 1


### PR DESCRIPTION
RunningElement pairs the two halves of a running header or footer: a `position: running(<name>)` on an element in the body, and a margin box pulling it back with `content: element(<name>)`. Every consumer hand-rolled that pair, and each one had to rediscover that the source element must be hidden when the document is not paginated, since `position: running()` means nothing outside Paged.js.

Two details of how Paged.js implements running elements decide how the rule has to be written, and getting either wrong leaves the element painting in the normal content flow instead of in its margin box.

Paged.js hides the source element itself, by setting an inline `display: none` on everything the `position: running()` rule selects. It does that against the parsed content fragment, which holds the body's children rather than the body itself, so a selector rooted at `body` matches nothing there and the element is never hidden. The rule is therefore emitted unrooted, and hiding for the unpaginated case is left to a separate `body`-rooted rule, which is only ever matched against the live document. For the same reason the rule must not carry a `display: block` of its own: an important declaration would outrank the inline `display: none` that Paged.js relies on, reintroducing the leak from the other direction.

The margin box also has to exist for the element to have anywhere to go, and a region supplied as a Pydantic field default never passes through the `mode="before"` validator that names it and attaches its rule, because defaults are not validated. A Page subclass declaring `bottom_left: PageRegion = Field(default=...)` -- the ordinary way to build a report page -- therefore emitted no margin box at all. The after-validator does run for defaults, so it repairs the naming and the rule there.

suppress_first_page_regions covers the near-universal case of a cover page that should not carry a running header or footer, which otherwise means writing a rule against paged.js internal margin-box class names.